### PR TITLE
Makes the height of the jumbotron relative to the viewport size

### DIFF
--- a/src/static/stylus/home.styl
+++ b/src/static/stylus/home.styl
@@ -1,2 +1,8 @@
 #jumbo_logo
-    margin-left -45px
+  margin-left -45px
+
+html
+  height 100vh
+
+.jumbotron
+  min-height 100vh


### PR DESCRIPTION
Removes the whitespace from the bottom of the homepage and fills the screen with the jumbotron.

Resolves #65