### PR TITLE
Removed toc item sidebar call. It's handled by hamburger button now

### DIFF
--- a/src/static/js/ours/init.js
+++ b/src/static/js/ours/init.js
@@ -17,9 +17,6 @@ $(document).ready(function () {
             }
         })
 
-    // create sidebar and attach to menu open
-    $('.ui.sidebar').sidebar('attach events', '.toc.item')
-
     // Make base template dropdown not change text on selection
     $("#user_dropdown").dropdown({
         action: 'hide'


### PR DESCRIPTION
Resolves issue #74 

Removes line in init.js that calls .toc.item class which no longer exists. The #hamburger_button ID is used to call the sidebar.