### PR TITLE
added riot versions for CircleCI and Docker builder

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -6,6 +6,6 @@ WORKDIR /app
 
 # Install packages
 ADD package.json .
-RUN npm install npm-watch stylus riot -g
+RUN npm install npm-watch stylus riot@3.13.2 -g
 
 CMD npm-watch

--- a/circle.yml
+++ b/circle.yml
@@ -37,7 +37,7 @@ jobs:
       # Setup env, background tasks, cache
       - run: curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
       - run: nvm install 6.14.4
-      - run: npm install stylus riot -g
+      - run: npm install stylus riot@3.13.2 -g
       - run: npm run build-stylus
       - run: npm run build-riot
 


### PR DESCRIPTION
should we add version to riot like I did here? or should we update the riot compile script to use be compatible with whatever changed in riot 4?