### PR TITLE
better unpacking exception handling

### DIFF
--- a/src/apps/competitions/unpackers/v1.py
+++ b/src/apps/competitions/unpackers/v1.py
@@ -9,8 +9,8 @@ class V15Unpacker(BaseUnpacker):
         super().__init__(*args, **kwargs)
 
         # Just in case docker image is blank (""), replace with default value
-        docker_image = self.competition_yaml.get('competition_docker_image', 'codalab/codalab-legacy:py3')
-        if docker_image == "":
+        docker_image = self.competition_yaml.get('competition_docker_image')
+        if not docker_image:
             docker_image = "codalab/codalab-legacy:py3"
 
         self.competition = {

--- a/src/apps/competitions/unpackers/v1.py
+++ b/src/apps/competitions/unpackers/v1.py
@@ -7,11 +7,17 @@ from competitions.unpackers.utils import CompetitionUnpackingException, get_date
 class V15Unpacker(BaseUnpacker):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # Just in case docker image is blank (""), replace with default value
+        docker_image = self.competition_yaml.get('competition_docker_image', 'codalab/codalab-legacy:py3')
+        if docker_image == "":
+            docker_image = "codalab/codalab-legacy:py3"
+
         self.competition = {
             "title": self.competition_yaml.get('title'),
             "logo": None,
             "registration_auto_approve": not self.competition_yaml.get('has_registration', True),
-            "docker_image": self.competition_yaml.get('competition_docker_image', 'codalab/codalab-legacy:py3'),
+            "docker_image": docker_image,
             "pages": [],
             "phases": [],
             "leaderboards": [],


### PR DESCRIPTION
fixes #273 

# Example

render of the following error dict:

```
{
    "pages": {
        "content": ["This field may not be blank."]
    }
}
```

![image](https://user-images.githubusercontent.com/2185159/70070662-d4606e80-15a8-11ea-93de-7d7824d254de.png)


# known issues

may not make 100% sense to a v1.5 person as the errors correspond more directly to V2 YAML =\