### PR TITLE
Asyncio instead of threads in compute worker

### DIFF
--- a/Dockerfile.compute_worker
+++ b/Dockerfile.compute_worker
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.8
 
 # This makes output not buffer and return immediately, nice for seeing results in stdout
 ENV PYTHONUNBUFFERED 1

--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -260,17 +260,19 @@ class Run:
 
             while any(v["continue"] for v in logs.values()):
                 for value in logs.values():
-                    out = await value["stream"].readline()
-                    if out:
-                        value["data"] += out
-                        print("WS: " + str(out))
-                        await websocket.send(json.dumps({
-                            "kind": kind,
-                            "message": out.decode()
-                        }))
-                    else:
-                        value["continue"] = False
-                    await asyncio.sleep(.1)
+                    try:
+                        out = await asyncio.wait_for(value["stream"].readline(), timeout=.1)
+                        if out:
+                            value["data"] += out
+                            print("WS: " + str(out))
+                            await websocket.send(json.dumps({
+                                "kind": kind,
+                                "message": out.decode()
+                            }))
+                        else:
+                            value["continue"] = False
+                    except asyncio.TimeoutError:
+                        continue
 
             end = time.time()
 
@@ -287,7 +289,10 @@ class Run:
                     logger.info(f'[{key}]\n{value["data"]}')
                     self._put_file(value["location"], raw_data=value["data"])
 
-    def _run_program_directory(self, program_dir, kind, can_be_output=False):
+            logger.info("Program finished")
+            return proc
+
+    async def _run_program_directory(self, program_dir, kind, can_be_output=False):
         # If the directory doesn't even exist, move on
         if not os.path.exists(program_dir):
             logger.info(f"{program_dir} not found, no program to execute")
@@ -371,7 +376,6 @@ class Run:
         docker_cmd += [self.docker_image]
 
         # Handle Legacy competitions by replacing anything in the run command
-
         command = replace_legacy_metadata_command(
             command=command,
             kind=kind,
@@ -384,15 +388,8 @@ class Run:
 
         logger.info(f"Running program = {' '.join(docker_cmd)}")
 
-        # This runs the docker command and asynchronously passes data
-        if self.ingestion_only_during_scoring and self.is_scoring:
-            asyncio.set_event_loop(asyncio.new_event_loop())
-            asyncio.get_event_loop().run_until_complete(self._run_docker_cmd(docker_cmd, kind=kind))
-            asyncio.get_event_loop().close()
-        else:
-            asyncio.get_event_loop().run_until_complete(self._run_docker_cmd(docker_cmd, kind=kind))
-
-        logger.info("Program finished")
+        # This runs the docker command and asynchronously passes data back via websocket
+        return await self._run_docker_cmd(docker_cmd, kind=kind)
 
     def _put_dir(self, url, directory):
         logger.info("Putting dir %s in %s" % (directory, url))
@@ -479,19 +476,14 @@ class Run:
 
         logger.info("Running scoring program, and then ingestion program")
 
-        if self.ingestion_only_during_scoring and self.is_scoring:
-            asyncio.get_event_loop()
-            asyncio.get_child_watcher()
-            scoring_thread = threading.Thread(target=self._run_program_directory, args=(program_dir, 'program', True))
-            ingestion_thread = threading.Thread(target=self._run_program_directory, args=(ingestion_program_dir, 'ingestion'))
+        loop = asyncio.new_event_loop()
 
-            scoring_thread.start()
-            ingestion_thread.start()
-            scoring_thread.join()
-            ingestion_thread.join()
-        else:
-            self._run_program_directory(program_dir, kind='program', can_be_output=True)
-            self._run_program_directory(ingestion_program_dir, kind='ingestion')
+        gathered_tasks = asyncio.gather(
+            self._run_program_directory(program_dir, kind='program', can_be_output=True),
+            self._run_program_directory(ingestion_program_dir, kind='ingestion'),
+            loop=loop,
+        )
+        loop.run_until_complete(gathered_tasks)
 
         if self.is_scoring:
             self._update_status(STATUS_FINISHED)

--- a/docker/compute_worker/compute_worker_requirements.txt
+++ b/docker/compute_worker/compute_worker_requirements.txt
@@ -1,5 +1,5 @@
 celery==4.2.1
 requests==2.18.4
 watchdog==0.8.3
-websockets==6.0
+websockets==8.1
 aiofiles==0.4.0

--- a/src/apps/competitions/consumers.py
+++ b/src/apps/competitions/consumers.py
@@ -29,7 +29,6 @@ class SubmissionIOConsumer(AsyncWebsocketConsumer):
         async with aiofiles.open(submission_output_path, 'a+') as f:
             await f.write(f'{text_data}\n')
 
-        # TODO: Await to broadcast to everyone listening to this submission key or whatever
         await self.channel_layer.group_send(f"submission_listening_{user_pk}", {
             'type': 'submission.message',
             'text': json.loads(text_data),


### PR DESCRIPTION
# @ mention of reviewers
@jimmykodes 


# A brief description of the purpose of the changes contained in this PR.
Moves away from threads to use asyncio features



# A checklist for hand testing
- [x] Normal competition works (non-ingestion during scoring)
- [x] Ingestion during scoring works
- [x] AutoDL works, with many parallel jobs happening
- [x] A v1.5 competition still works



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

