### PR TITLE
Add Empty Help links/buttons

### DIFF
--- a/src/static/riot/competitions/competition_list.tag
+++ b/src/static/riot/competitions/competition_list.tag
@@ -31,9 +31,8 @@
                                     <!--<button class="mini ui button green icon" show="{ !competition.published }" onclick="{ publish_competition.bind(this, competition) }">
                                         <i class="icon external alternate"></i>
                                     </button>-->
-                                    <button
-                                        class="mini ui button published icon { grey: !competition.published, green: competition.published }"
-                                        onclick="{ toggle_competition_publish.bind(this, competition) }">
+                                    <button class="mini ui button published icon { grey: !competition.published, green: competition.published }"
+                                            onclick="{ toggle_competition_publish.bind(this, competition) }">
                                         <i class="icon file"></i>
                                     </button>
                                 </td>

--- a/src/static/riot/competitions/competition_list.tag
+++ b/src/static/riot/competitions/competition_list.tag
@@ -39,8 +39,9 @@
                                 </td>
                                 <td class="center aligned">
                                     <a href="{ URLS.COMPETITION_EDIT(competition.id) }"
-                                       class="mini ui button blue icon"><i
-                                        class="icon edit"></i> </a>
+                                       class="mini ui button blue icon">
+                                        <i class="icon edit"></i>
+                                    </a>
                                 </td>
                                 <td class="center aligned">
                                     <button class="mini ui button red icon"

--- a/src/static/riot/competitions/competition_list.tag
+++ b/src/static/riot/competitions/competition_list.tag
@@ -3,9 +3,13 @@
         <div class="ui middle aligned stackable grid container centered">
             <div class="row">
                 <div class="fourteen wide column">
-                    <div class="ui fluid four secondary pointing tabular menu">
+                    <div class="ui fluid six secondary pointing tabular menu">
                         <a class="active item" data-tab="running">Competitions I'm Running</a>
                         <a class="item" data-tab="participating">Competitions I'm In</a>
+                        <a class="item" href="" target="_blank">
+                            <i class="question icon"></i>
+                            Help
+                        </a>
                     </div>
                     <div class="ui active tab" data-tab="running">
                         <table class="ui celled compact table participation">

--- a/src/static/riot/competitions/competition_list.tag
+++ b/src/static/riot/competitions/competition_list.tag
@@ -3,13 +3,14 @@
         <div class="ui middle aligned stackable grid container centered">
             <div class="row">
                 <div class="fourteen wide column">
-                    <div class="ui fluid six secondary pointing tabular menu">
+                    <div class="ui fluid secondary pointing tabular menu">
                         <a class="active item" data-tab="running">Competitions I'm Running</a>
                         <a class="item" data-tab="participating">Competitions I'm In</a>
-                        <a class="item" href="" target="_blank">
-                            <i class="question icon"></i>
-                            Help
-                        </a>
+                        <div class="right menu">
+                            <div class="item">
+                                <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Management-&-List"></help_button>
+                            </div>
+                        </div>
                     </div>
                     <div class="ui active tab" data-tab="running">
                         <table class="ui celled compact table participation">
@@ -30,13 +31,16 @@
                                     <!--<button class="mini ui button green icon" show="{ !competition.published }" onclick="{ publish_competition.bind(this, competition) }">
                                         <i class="icon external alternate"></i>
                                     </button>-->
-                                    <button class="mini ui button published icon { grey: !competition.published, green: competition.published }" onclick="{ toggle_competition_publish.bind(this, competition) }">
+                                    <button
+                                        class="mini ui button published icon { grey: !competition.published, green: competition.published }"
+                                        onclick="{ toggle_competition_publish.bind(this, competition) }">
                                         <i class="icon file"></i>
                                     </button>
                                 </td>
                                 <td class="center aligned">
-                                    <a href="{ URLS.COMPETITION_EDIT(competition.id) }" class="mini ui button blue icon"><i
-                                            class="icon edit"></i> </a>
+                                    <a href="{ URLS.COMPETITION_EDIT(competition.id) }"
+                                       class="mini ui button blue icon"><i
+                                        class="icon edit"></i> </a>
                                 </td>
                                 <td class="center aligned">
                                     <button class="mini ui button red icon"
@@ -80,7 +84,7 @@
             $('.tabular.menu .item').tab();
         })
 
-        self.update_competitions = function() {
+        self.update_competitions = function () {
             self.get_participating_in_competitions()
             self.get_running_competitions()
         }
@@ -94,7 +98,7 @@
 
         self.get_participating_in_competitions = function () {
             self.get_competitions_wrapper({participating_in: true})
-                .done(function(data){
+                .done(function (data) {
                     self.participating_competitions = data
                     self.update()
                 })
@@ -102,7 +106,7 @@
 
         self.get_running_competitions = function () {
             self.get_competitions_wrapper({mine: true})
-                .done(function(data){
+                .done(function (data) {
                     self.running_competitions = data
                     self.update()
                 })
@@ -137,6 +141,7 @@
             .published.icon.grey
                 opacity 0.65
                 transition 0.25s all ease-in-out
+
                 &:hover
                     background-color #21ba45
 

--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -8,7 +8,12 @@
             <div class="item" data-tab="phases-tab">Phases</div>
             <div class="item" data-tab="participate-tab">My Submissions</div>
             <div class="item" data-tab="results-tab">Results</div>
-            <a class="item" href="" target="_blank"><i class="question icon"></i>Help</a>
+            <div class="right menu">
+                <div class="item">
+                    <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Detail-Page"
+                                 tooltip_position="left center"></help_button>
+                </div>
+            </div>
         </div>
 
         <!-- TODO DECIDE WHETHER WE WANT TO USE THIS HOME-TAB OR LEAVE IT. -->

--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -8,6 +8,7 @@
             <div class="item" data-tab="phases-tab">Phases</div>
             <div class="item" data-tab="participate-tab">My Submissions</div>
             <div class="item" data-tab="results-tab">Results</div>
+            <a class="item" href="" target="_blank"><i class="question icon"></i>Help</a>
         </div>
 
         <!-- TODO DECIDE WHETHER WE WANT TO USE THIS HOME-TAB OR LEAVE IT. -->

--- a/src/static/riot/competitions/editor/form.tag
+++ b/src/static/riot/competitions/editor/form.tag
@@ -84,17 +84,21 @@
             </div>
         </div>
 
-        <div class="row centered">
-            <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
-            <button class="ui primary button { disabled: !are_all_sections_valid() }" onclick="{ save_and_publish }">
-                Save and Publish
-            </button>
-            <button class="ui grey button { disabled: !are_all_sections_valid() }" onclick="{ save_as_draft }">
-                Save as Draft
-            </button>
-            <button class="ui basic red button discard" onclick="{ discard }">
-                Discard Changes
-            </button>
+        <div class="center aligned row">
+            <div class="column">
+                <help_button
+                    href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
+                <button class="ui primary button { disabled: !are_all_sections_valid() }"
+                        onclick="{ save_and_publish }">
+                    Save and Publish
+                </button>
+                <button class="ui grey button { disabled: !are_all_sections_valid() }" onclick="{ save_as_draft }">
+                    Save as Draft
+                </button>
+                <button class="ui basic red button discard" onclick="{ discard }">
+                    Discard Changes
+                </button>
+            </div>
         </div>
     </div>
 

--- a/src/static/riot/competitions/editor/form.tag
+++ b/src/static/riot/competitions/editor/form.tag
@@ -31,7 +31,7 @@
                     <errors errors="{errors}"></errors>
                 </div>
 
-                <div class="ui pointing six item secondary menu">
+                <div class="ui pointing seven item secondary menu">
                     <a class="active item" data-tab="competition_details">
                         <i class="checkmark box icon green" show="{ valid_sections.details && !errors.details }"></i>
                         <i class="minus circle icon red" show="{ errors.details }"></i>
@@ -61,6 +61,10 @@
                         <i class="checkmark box icon green" show="{ valid_sections.collaborators && !errors.collaborators }"></i>
                         <i class="minus circle icon red" show="{ errors.collaborators }"></i>
                         Collaborators
+                    </a>
+                    <a class="item" target="_blank" href="">
+                        <i class="question icon"></i>
+                        Help
                     </a>
                 </div>
                 <div class="ui active tab" data-tab="competition_details">

--- a/src/static/riot/competitions/editor/form.tag
+++ b/src/static/riot/competitions/editor/form.tag
@@ -86,8 +86,7 @@
 
         <div class="center aligned row">
             <div class="column">
-                <help_button
-                    href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
+                <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
                 <button class="ui primary button { disabled: !are_all_sections_valid() }"
                         onclick="{ save_and_publish }">
                     Save and Publish

--- a/src/static/riot/competitions/editor/form.tag
+++ b/src/static/riot/competitions/editor/form.tag
@@ -31,7 +31,7 @@
                     <errors errors="{errors}"></errors>
                 </div>
 
-                <div class="ui pointing seven item secondary menu">
+                <div class="ui six item secondary pointing menu">
                     <a class="active item" data-tab="competition_details">
                         <i class="checkmark box icon green" show="{ valid_sections.details && !errors.details }"></i>
                         <i class="minus circle icon red" show="{ errors.details }"></i>
@@ -62,10 +62,6 @@
                         <i class="minus circle icon red" show="{ errors.collaborators }"></i>
                         Collaborators
                     </a>
-                    <a class="item" target="_blank" href="">
-                        <i class="question icon"></i>
-                        Help
-                    </a>
                 </div>
                 <div class="ui active tab" data-tab="competition_details">
                     <competition-details errors="{ errors.details }"></competition-details>
@@ -89,6 +85,7 @@
         </div>
 
         <div class="row centered">
+            <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
             <button class="ui primary button { disabled: !are_all_sections_valid() }" onclick="{ save_and_publish }">
                 Save and Publish
             </button>

--- a/src/static/riot/competitions/upload.tag
+++ b/src/static/riot/competitions/upload.tag
@@ -2,12 +2,13 @@
     <div class="ui grid container">
         <div class="eight wide column centered form-empty">
             <div class="ui segment">
-                <h1 class="ui header">
-                    Competition upload
-                    <div class="sub header">
-                        For more information on creating bundles, please visit the <a href="https://github.com/codalab/competitions-v2/wiki">Wiki</a>!
-                    </div>
-                </h1>
+                <div class="flex-header">
+                    <h1 class="ui header">Competition upload</h1>
+                    <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Bundle"
+                                 tooltip="More information on bundle creation">
+                    </help_button>
+                </div>
+
 
                 <!-- File selection state view -->
                 <form hide="{ listening_for_status || resulting_competition || resulting_details }" class="ui form coda-animated {error: errors}" ref="form" enctype="multipart/form-data">
@@ -183,5 +184,10 @@
 
         .loader
             padding-bottom 20px
+
+        .flex-header
+            display flex
+            flex-direction row
+            justify-content space-between
     </style>
 </competition-upload>

--- a/src/static/riot/datasets/help_button.tag
+++ b/src/static/riot/datasets/help_button.tag
@@ -1,0 +1,9 @@
+<help_button>
+    <a class="ui mini circular icon button"
+       data-tooltip="{opts.tooltip || 'Help'}"
+       data-position="{opts.tooltip_position || 'top center'}"
+       href="{opts.href}"
+       target="_blank">
+        <i class="question icon"></i>
+    </a>
+</help_button>

--- a/src/static/riot/management.tag
+++ b/src/static/riot/management.tag
@@ -4,6 +4,7 @@
     <div class="ui top attached tabular menu">
         <div class="active item" data-tab="datasets">Datasets</div>
         <div class="item" data-tab="tasks">Tasks</div>
+        <a class="item" href="" target="_blank"><i class="question icon"></i>Help</a>
     </div>
     <div class="ui active bottom attached tab segment" data-tab="datasets">
         <data-management></data-management>

--- a/src/static/riot/management.tag
+++ b/src/static/riot/management.tag
@@ -6,7 +6,7 @@
         <div class="item" data-tab="tasks">Tasks</div>
         <div class="right menu">
             <div class="item">
-                <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Bundle"
+                <help_button href="https://github.com/codalab/competitions-v2/wiki/Task-&-Dataset-Management"
                              tooltip_position="left center">
                 </help_button>
             </div>

--- a/src/static/riot/management.tag
+++ b/src/static/riot/management.tag
@@ -4,7 +4,13 @@
     <div class="ui top attached tabular menu">
         <div class="active item" data-tab="datasets">Datasets</div>
         <div class="item" data-tab="tasks">Tasks</div>
-        <a class="item" href="" target="_blank"><i class="question icon"></i>Help</a>
+        <div class="right menu">
+            <div class="item">
+                <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Bundle"
+                             tooltip_position="left center">
+                </help_button>
+            </div>
+        </div>
     </div>
     <div class="ui active bottom attached tab segment" data-tab="datasets">
         <data-management></data-management>

--- a/src/static/riot/queues/management.tag
+++ b/src/static/riot/queues/management.tag
@@ -1,15 +1,32 @@
 <queues-list>
-    <div class="ui icon input">
-        <input type="text" placeholder="Search by name..." ref="search" onkeyup="{filter.bind(this, undefined)}">
-        <i class="search icon"></i>
+    <div class="ui horizontal list">
+        <div class="item">
+            <div class="ui icon input">
+                <input type="text" placeholder="Search by name..." ref="search"
+                       onkeyup="{filter.bind(this, undefined)}">
+                <i class="search icon"></i>
+            </div>
+        </div>
+
+        <div class="item">
+            <div class="ui checkbox" onclick="{ filter.bind(this, undefined) }">
+                <label>Show Public Queues</label>
+                <input type="checkbox" ref="public">
+            </div>
+        </div>
+
+        <a class="item" href="" target="_blank">
+            <i class="question icon"></i>
+            Help
+        </a>
+
     </div>
-    <div class="ui checkbox" onclick="{ filter.bind(this, undefined) }">
-        <label>Show Public Queues</label>
-        <input type="checkbox" ref="public">
-    </div>
-    <div class="ui green right floated labeled icon button" onclick="{ show_modal.bind(this, undefined) }"><i class="add circle icon"></i>
+
+    <div class="ui green right floated labeled icon button" onclick="{ show_modal.bind(this, undefined) }"><i
+            class="add circle icon"></i>
         Create Queue
     </div>
+
     <table class="ui {selectable: queues.length > 0} celled compact table">
         <thead>
         <tr>

--- a/src/static/riot/queues/management.tag
+++ b/src/static/riot/queues/management.tag
@@ -14,12 +14,9 @@
                 <input type="checkbox" ref="public">
             </div>
         </div>
-
-        <a class="item" href="" target="_blank">
-            <i class="question icon"></i>
-            Help
-        </a>
-
+        <div class="item">
+            <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Bundle" tooltip_position="right center"></help_button>
+        </div>
     </div>
 
     <div class="ui green right floated labeled icon button" onclick="{ show_modal.bind(this, undefined) }"><i

--- a/src/static/riot/queues/management.tag
+++ b/src/static/riot/queues/management.tag
@@ -9,7 +9,6 @@
                 <i class="search icon"></i>
             </div>
         </div>
-
         <div class="item">
             <div class="ui checkbox" onclick="{ filter.bind(this, undefined) }">
                 <label>Show Public Queues</label>
@@ -23,9 +22,8 @@
         </div>
     </div>
 
-    <div class="ui green right floated labeled icon button" onclick="{ show_modal.bind(this, undefined) }"><i
-            class="add circle icon"></i>
-        Create Queue
+    <div class="ui green right floated labeled icon button" onclick="{ show_modal.bind(this, undefined) }">
+        <i class="add circle icon"></i> Create Queue
     </div>
 
     <table class="ui {selectable: queues.length > 0} celled compact table">

--- a/src/static/riot/queues/management.tag
+++ b/src/static/riot/queues/management.tag
@@ -2,7 +2,9 @@
     <div class="ui horizontal list">
         <div class="item">
             <div class="ui icon input">
-                <input type="text" placeholder="Search by name..." ref="search"
+                <input type="text"
+                       placeholder="Search by name..."
+                       ref="search"
                        onkeyup="{filter.bind(this, undefined)}">
                 <i class="search icon"></i>
             </div>
@@ -15,7 +17,9 @@
             </div>
         </div>
         <div class="item">
-            <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Bundle" tooltip_position="right center"></help_button>
+            <help_button href="https://github.com/codalab/competitions-v2/wiki/Queue-Management"
+                         tooltip_position="right center">
+            </help_button>
         </div>
     </div>
 

--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -146,11 +146,6 @@
                                  each="{file_field in ['scoring_program', 'ingestion_program']}">
                                 <label>
                                     {_.startCase(file_field)}
-                                    <span data-tooltip="Something useful to know...!"
-                                          data-inverted=""
-                                          data-position="bottom center">
-                                        <i class=" grey help icon circle"></i>
-                                    </span>
                                 </label>
                                 <div class="ui fluid left icon labeled input search dataset" data-name="{file_field}">
                                     <i class="search icon"></i>
@@ -164,11 +159,6 @@
                             <div class="field" each="{file_field in ['reference_data', 'input_data']}">
                                 <label>
                                     {_.startCase(file_field)}
-                                    <span data-tooltip="Something useful to know...!"
-                                          data-inverted=""
-                                          data-position="bottom center">
-                                        <i class="grey help icon circle"></i>
-                                    </span>
                                 </label>
                                 <div class="ui fluid left icon labeled input search dataset" data-name="{file_field}">
                                     <i class="search icon"></i>

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -146,7 +146,8 @@
             </div>
             <div class="seven wide column">
                 <h4 class="ui inverted header">Codalab v2</h4>
-                <p>Join us on <a href="https://github.com/codalab/competitions-v2">Github</a> for contact &amp; bug reports</p>
+                <p>Join us on <a href="https://github.com/codalab/competitions-v2" target="_blank">Github</a> for contact &amp; bug reports</p>
+                <p>Questions about the platform? See our <a href="https://github.com/codalab/competitions-v2/wiki" target="_blank">Wiki</a> for more information.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Adding help button links to relevant wiki pages throughout the site.

# A checklist for hand testing
- [x] Help button links are visible on the following pages and link to the correct wiki page
  - [x] Queue management
  - [x] Competition management
  - [x] Task/Dataset management
  - [x] Competition editor
  - [x] Competition Bundle Upload
  - [x] Competition Detail Page

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

