### PR TITLE
[WIP] Fixing flower/rabbit admin tools

### DIFF
--- a/Dockerfile.compute_worker
+++ b/Dockerfile.compute_worker
@@ -17,7 +17,4 @@ CMD celery -A compute_worker worker \
     -n compute-worker@%n \
     -Ofast \
     -Ofair \
-    --concurrency=1 \
-    --without-gossip \
-    --without-mingle \
-    --without-heartbeat
+    --concurrency=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
         max-file: "10"
 
   compute_worker:
-    command: bash -c "watchmedo auto-restart -p '*.py' --recursive -- celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n -Ofast -Ofair --concurrency=1 --without-gossip --without-mingle --without-heartbeat"
+    command: bash -c "watchmedo auto-restart -p '*.py' --recursive -- celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n -Ofast -Ofair --concurrency=1"
     working_dir: /app
     build:
       context: .
@@ -181,19 +181,27 @@ services:
   #-----------------------------------------------
   #   Flower Service
   #-----------------------------------------------
+#  flower:
+#    env_file: .env
+#    build:
+#      context: .
+#      dockerfile: Dockerfile.flower
+#    environment:
+#      # These aren't set in .env
+#      - AMQP_USERNAME=${RABBITMQ_DEFAULT_USER}
+#      - AMQP_PASSWORD=${RABBITMQ_DEFAULT_PASS}
+#      - AMQP_HOST=rabbit
+#      - AMQP_ADMIN_HOST=rabbit
+#      - AMQP_PORT=${RABBITMQ_PORT}
+#    ports:
+#      - 5555:5555
+#    depends_on:
+#      - rabbit
   flower:
     env_file: .env
-    build:
-      context: .
-      dockerfile: Dockerfile.flower
+    image: mher/flower
     environment:
-      # These aren't set in .env
-      - AMQP_USERNAME=${RABBITMQ_DEFAULT_USER}
-      - AMQP_PASSWORD=${RABBITMQ_DEFAULT_PASS}
-      - AMQP_HOST=rabbit
-      - AMQP_ADMIN_HOST=rabbit
-      - AMQP_PORT=${RABBITMQ_PORT}
+      #- CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbit:${RABBITMQ_PORT}//
     ports:
       - 5555:5555
-    depends_on:
-      - rabbit


### PR DESCRIPTION
# @ mention of reviewers
@jimmykodes 


# A brief description of the purpose of the changes contained in this PR.
Previously Flower/RabbitMQ management would not have very many useful details for Rabbit jobs. We couldn't see compute workers or which jobs they were picking up. This PR should fix that.

Resolves #317 


# A checklist for hand testing
- [ ] go to host:5555 and login with flower basic auth to get details about flower while tasks are running, each compute worker should be listed and the jobs they're executing should be apparent


# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge

