### PR TITLE
fixing issues w/ creating tasks and downloading their datasets

### DIFF
--- a/src/apps/api/serializers/datasets.py
+++ b/src/apps/api/serializers/datasets.py
@@ -50,6 +50,17 @@ class DataSerializer(DefaultUserCreateMixin, serializers.ModelSerializer):
         return instance
 
 
+class DataSimpleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Data
+        fields = (
+            'id',
+            'type',
+            'name',
+            'key',
+        )
+
+
 class DataDetailSerializer(serializers.ModelSerializer):
     created_by = serializers.CharField(source='created_by.username')
 

--- a/src/apps/api/serializers/tasks.py
+++ b/src/apps/api/serializers/tasks.py
@@ -5,7 +5,6 @@ from api.mixins import DefaultUserCreateMixin
 from api.serializers.datasets import DataDetailSerializer, DataSimpleSerializer
 from datasets.models import Data
 from tasks.models import Task, Solution
-from utils.data import make_url_sassy
 
 
 class SolutionSerializer(WritableNestedModelSerializer):

--- a/src/apps/api/views/tasks.py
+++ b/src/apps/api/views/tasks.py
@@ -52,13 +52,11 @@ class TaskViewSet(ModelViewSet):
         return qs.order_by('-created_when')
 
     def get_serializer_class(self):
-        if self.action == 'retrieve':
-            # is a GET request w/ a PK
+        if self.request.method == 'GET':
+            if self.action == 'list':
+                return serializers.TaskListSerializer
             return serializers.TaskDetailSerializer
-        elif self.action == 'list':
-            return serializers.TaskListSerializer
-        else:
-            return serializers.TaskSerializer
+        return serializers.TaskSerializer
 
     def update(self, request, *args, **kwargs):
         task = self.get_object()

--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -70,9 +70,10 @@
             <div class="ui divider" show="{selected_task.description}"></div>
             <div><strong>Created By:</strong> {selected_task.created_by}</div>
             <div><strong>Key:</strong> {selected_task.key}</div>
-            <div><strong>Has Been Validated <span data-inverted=""
-                                                  data-tooltip="A task has been validated once one of its solutions has successfully been run against it">
-                <i class="question circle icon"></i></span>:</strong> {selected_task.validated ? "Yes" : "No"}</div>
+            <div><strong>Has Been Validated
+                <span data-tooltip="A task has been validated once one of its solutions has successfully been run against it">
+                    <i class="question circle icon"></i>
+                </span>:</strong> {selected_task.validated ? "Yes" : "No"}</div>
             <div><strong>Is Public:</strong> {selected_task.is_public ? "Yes" : "No"}</div>
             <div if="{selected_task.validated}"
                  class="ui right floated small green icon button"
@@ -87,12 +88,22 @@
                 <table class="ui table">
                     <thead>
                     <tr>
-                        <th>Files</th>
+                        <th>Type</th>
+                        <th>Name</th>
+                        <th></th>
                     </tr>
                     </thead>
                     <tbody>
-                    <tr each="{file in selected_task.files}">
-                        <td><a href="{URLS.DATASET_DOWNLOAD(file.key)}">{file.name}</a></td>
+                    <tr each="{file in file_types}" if="{selected_task[file]}">
+                        <td>{selected_task[file].type}</td>
+                        <td>{selected_task[file].name}</td>
+                        <td class="collapsing">
+                            <span data-tooltip="Download this dataset">
+                                <a href="{URLS.DATASET_DOWNLOAD(selected_task[file].key)}">
+                                    <i class="download green icon"></i>
+                                </a>
+                            </span>
+                        </td>
                     </tr>
                     </tbody>
                 </table>
@@ -189,6 +200,12 @@
         self.form_datasets = {}
         self.selected_task = {}
         self.page = 1
+        self.file_types = [
+            'input_data',
+            'reference_data',
+            'scoring_program',
+            'ingestion_program'
+        ]
 
 
         self.one("mount", function () {


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
Should fix downloading datasets from task detail modal.
Should now be able to create tasks via the Task Creation modal (wasn't working due to an error "instance has no attribute 'validated'" since creating the object did not pass through the queryset annotation adding the validated field.
Also cleaned up some task query counts and serializer shtuff.


# A checklist for hand testing
- [x] Can create task via the "Create Task" button on task management, using uploaded datasets.
- [x] When clicking on a row in the task management table, should bring up a modal with all the datasets relevant to the task, and allow you to download them via green download button on the right side of the files table.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

Resolves #286 