### PR TITLE
Compute worker dataset caching

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,7 @@ services:
       - BROKER_URL=pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}//
       # Make the worker leave behind the submission so we can examine it
       - CODALAB_IGNORE_CLEANUP_STEP=1
+      - MAX_CACHE_DIR_SIZE_GB=.1
     logging:
       options:
         max-size: "20k"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,6 @@ services:
       - BROKER_URL=pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}//
       # Make the worker leave behind the submission so we can examine it
       - CODALAB_IGNORE_CLEANUP_STEP=1
-      - MAX_CACHE_DIR_SIZE_GB=.1
     logging:
       options:
         max-size: "20k"

--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -113,11 +113,11 @@ def get_folder_size_in_gb(folder):
         return 0
     total_size = os.path.getsize(folder)
     for item in os.listdir(folder):
-        itempath = os.path.join(folder, item)
-        if os.path.isfile(itempath):
-            total_size += os.path.getsize(itempath)
-        elif os.path.isdir(itempath):
-            total_size += get_folder_size_in_gb(itempath)
+        path = os.path.join(folder, item)
+        if os.path.isfile(path):
+            total_size += os.path.getsize(path)
+        elif os.path.isdir(path):
+            total_size += get_folder_size_in_gb(path)
     return total_size / 1024 / 1024 / 1024
 
 

--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -277,24 +277,23 @@ class Run:
 
     def _get_bundle(self, url, destination, cache=True):
         """Downloads zip from url and unzips into destination. If cache=True then url is hashed and checked
-        against existence in CACHE_DIR/<hashed_url>, and only downloaded if needed. Cache size is checked
+        against existence in CACHE_DIR/<hashed_url> and only downloaded if needed. Cache size is checked
         during the prepare step and cleared if it's over MAX_CACHE_DIR_SIZE_GB.
 
         :returns zip file path"""
         logger.info(f"Getting bundle {url} to unpack @{destination}")
+        download_needed = True
 
         if cache:
             # Hash url and download it if it doesn't exist
             url_without_params = url.split("?")[0]
             url_hash = hashlib.sha256(url_without_params.encode('utf8')).hexdigest()
             bundle_file = os.path.join(CACHE_DIR, url_hash)
-            if not os.path.exists(bundle_file):
-                try:
-                    urlretrieve(url, bundle_file)
-                except HTTPError:
-                    raise SubmissionException(f"Problem fetching {url} to put in {destination}")
+            download_needed = not os.path.exists(bundle_file)
         else:
             bundle_file = tempfile.NamedTemporaryFile(delete=False).name
+
+        if download_needed:
             try:
                 urlretrieve(url, bundle_file)
             except HTTPError:

--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -31,9 +31,6 @@ logger = logging.getLogger()
 # Setup base directories used by all submissions
 BASE_DIR = "/tmp/codalab-v2"
 CACHE_DIR = os.path.join(BASE_DIR, "cache")
-if not os.path.exists(CACHE_DIR):
-    os.mkdir(CACHE_DIR)
-
 MAX_CACHE_DIR_SIZE_GB = float(os.environ.get('MAX_CACHE_DIR_SIZE_GB', 10))
 
 # Status options for submissions
@@ -547,7 +544,9 @@ class Run:
     def prepare(self):
         self._update_status(STATUS_PREPARING)
 
-        # Before downloading any new data, let's make sure CACHE_DIR size isn't getting out of control
+        # Setup cache and prune if it's out of control
+        if not os.path.exists(CACHE_DIR):
+            os.mkdir(CACHE_DIR)
         self._prune_cache_dir()
 
         # A run *may* contain the following bundles, let's grab them and dump them in the appropriate

--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -34,7 +34,7 @@ CACHE_DIR = os.path.join(BASE_DIR, "cache")
 if not os.path.exists(CACHE_DIR):
     os.mkdir(CACHE_DIR)
 
-MAX_CACHE_DIR_SIZE_GB = 10
+MAX_CACHE_DIR_SIZE_GB = float(os.environ.get('MAX_CACHE_DIR_SIZE_GB', 10))
 
 # Status options for submissions
 STATUS_NONE = "None"

--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -571,6 +571,7 @@ class Run:
 
         for url, path in bundles:
             if url is not None:
+                # At the moment let's just cache input & reference data
                 cache_this_bundle = path in ('input_data', 'input/ref')
                 zip_file = self._get_bundle(url, path, cache=cache_this_bundle)
 


### PR DESCRIPTION
# @ mention of reviewers
@jimmykodes 


# A brief description of the purpose of the changes contained in this PR.
Adds dataset caching to speed up compute worker runs. (issue #334)


# Known issues/discussion
1. ~This caches _everything.._ could probably not cache submissions and maybe some other things?~ Now only caches `input_data` and `reference_data`
1. Should I move these utility functions somewhere else? This is getting kinda gross structure wise. A simple "entry point" module (ie worker.py) with some peripheral modules (ie utils.py, run.py?) seems to be easier to grok..


# A checklist for hand testing
- [ ] submissions should process more quickly with fatty datasets, ideally test with large AutoDL datasets
- [ ] cache cleaned when cache size exceeds `MAX_CACHE_DIR_SIZE_GB` 
- [ ] changing `MAX_CACHE_DIR_SIZE_GB` env var works properly (converts str to float for comparison)

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge

