### PR TITLE
Adds fabric worker mgmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ insert_final_newline = true
 tab_width = 4
 trim_trailing_whitespace = true
 
+[*.{yml,yaml}]
+indent_size = 2
+tab_width = 2
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ package-lock.json
 artifacts/
 
 docker-compose.override.yml
+
+server_config.yaml

--- a/README.md
+++ b/README.md
@@ -109,8 +109,12 @@ pip install fab-classic==1.17.0
 ```
 
 Create a `server_config.yaml` in the root of this repository using:
-`cp server_config_sample.yaml server_config.yaml`
-as a template
+```
+cp server_config_sample.yaml server_config.yaml
+```
+
+Below is an example `server_config.yaml` that defines 2 roles `comp-gpu` and `comp-cpu`,
+one with gpu style workers (`is_gpu` and the nvidia `docker_image`) and one with cpu style workers
 
 ```yaml
 comp-gpu:
@@ -129,7 +133,9 @@ comp-cpu:
   docker_image: codalab/competitions-v2-compute-worker:latest
 ```
 
-then you can execute commands against a group of servers:
+You can of course create your own `docker_image` and specify it here.
+
+You can execute commands against a role:
 
 ```bash
 ❯ fab -R comp-gpu status

--- a/README.md
+++ b/README.md
@@ -99,3 +99,44 @@ $ nvidia-docker run \
     --log-opt max-file=3 \
     codalab/competitions-v2-compute-worker:nvidia 
 ```
+
+# Worker management
+
+Outside of docker containers install [Fabric](http://fabfile.org/) like so:
+
+```bash
+pip install fab-classic
+```
+
+and create a `server_config.yaml` in the root of this respository:
+
+```yaml
+comp-gpu:
+  hosts:
+    - ubuntu@12.34.56.78
+    - ubuntu@12.34.56.79
+  broker_url: pyamqp://user:pass@host:port/vhost-gpu
+  is_gpu: true
+
+comp-cpu:
+  hosts:
+    - ubuntu@12.34.56.80
+  broker_url: pyamqp://user:pass@host:port/vhost-cpu
+  is_gpu: false
+```
+
+then you can execute commands against a group of servers:
+
+```bash
+❯ fab -R comp-gpu status
+..
+[ubuntu@12.34.56.78] out: CONTAINER ID        IMAGE                                           COMMAND                  CREATED             STATUS              PORTS               NAMES
+[ubuntu@12.34.56.78] out: 1d318268bee1        codalab/competitions-v2-compute-worker:nvidia   "/bin/sh -c 'celery …"   2 hours ago         Up 2 hours                              hardcore_greider
+..
+
+❯ fab -R comp-gpu update
+..
+(updates workers)
+```
+
+See available commands with `fab -l`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Outside of docker containers install [Fabric](http://fabfile.org/) like so:
 pip install fab-classic==1.17.0
 ```
 
-and create a `server_config.yaml` in the root of this respository:
+Create a `server_config.yaml` in the root of this repository using:
+`cp server_config_sample.yaml server_config.yaml`
+as a template
 
 ```yaml
 comp-gpu:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ nvidia-docker run \
 Outside of docker containers install [Fabric](http://fabfile.org/) like so:
 
 ```bash
-pip install fab-classic
+pip install fab-classic==1.17.0
 ```
 
 and create a `server_config.yaml` in the root of this respository:

--- a/README.md
+++ b/README.md
@@ -117,12 +117,14 @@ comp-gpu:
     - ubuntu@12.34.56.79
   broker_url: pyamqp://user:pass@host:port/vhost-gpu
   is_gpu: true
+  docker_image: codalab/competitions-v2-compute-worker:nvidia
 
 comp-cpu:
   hosts:
     - ubuntu@12.34.56.80
   broker_url: pyamqp://user:pass@host:port/vhost-cpu
   is_gpu: false
+  docker_image: codalab/competitions-v2-compute-worker:latest
 ```
 
 then you can execute commands against a group of servers:

--- a/fabfile.py
+++ b/fabfile.py
@@ -4,15 +4,30 @@ import yaml
 from fabric.api import env, run
 
 
+# Load in server config, here's a quick example:
+#   role_name:
+#     hosts:
+#       - ubuntu@12.34.56.78
+#     broker_url: pyamqp://user:pass@host:port/vhost-gpu
+#     is_gpu: true
+#     docker_image: codalab/competitions-v2-compute-worker:nvidia
+#
+# You select the role to run with like s:
+#   $ fab -R role_name <command>
 host_types = yaml.load(open('server_config.yaml').read())
 env.roledefs = host_types
 
 
 def status():
+    """Gets status of all docker containers on server"""
     run("docker ps")
 
 
 def update():
+    """Updates docker image on server and restarts the worker, based on server_config.yaml settings.
+
+    See README (Worker management section) for example settings."""
+    # Ensure that we're referencing one and only 1 role, so we don't accidentally update CPUs to GPUs
     if not env.effective_roles:
         print("ERROR: You must specify a role when running this task. I.e. fab -R some-gpu task_name`")
         return
@@ -20,6 +35,7 @@ def update():
         print("ERROR: Only specify 1 role (because we need 1 broker_url) when running this task")
         return
 
+    # Read settings from our server_config.yaml config
     role = env.effective_roles[0]
     broker_url = env.roledefs[role]["broker_url"]
     is_gpu = env.roledefs[role]["is_gpu"]
@@ -32,6 +48,7 @@ def update():
         docker_process = "docker"
         nvidia_sock = ""
 
+    # Build our docker command ensuring the nvidia socket is attached if we're in gpu mode
     docker_command = f"""{docker_process} run \
         -v /tmp/codalab-v2:/tmp/codalab-v2 \
         -v /var/run/docker.sock:/var/run/docker.sock \
@@ -41,8 +58,7 @@ def update():
         --restart unless-stopped \
         --log-opt max-size=50m \
         --log-opt max-file=3 \
-        {docker_image}
-    """
+        {docker_image}"""
 
     # Stop and remove containers
     run("docker stop $(docker ps -aq)")

--- a/fabfile.py
+++ b/fabfile.py
@@ -23,14 +23,13 @@ def update():
     role = env.effective_roles[0]
     broker_url = env.roledefs[role]["broker_url"]
     is_gpu = env.roledefs[role]["is_gpu"]
+    docker_image = env.roledefs[role]["docker_image"]
 
     if is_gpu:
         docker_process = "nvidia-docker"
-        docker_image = "codalab/competitions-v2-compute-worker:nvidia"
         nvidia_sock = "-v /var/lib/nvidia-docker/nvidia-docker.sock:/var/lib/nvidia-docker/nvidia-docker.sock"
     else:
         docker_process = "docker"
-        docker_image = "codalab/competitions-v2-compute-worker:latest"
         nvidia_sock = ""
 
     docker_command = f"""{docker_process} run \

--- a/fabfile.py
+++ b/fabfile.py
@@ -19,7 +19,7 @@ env.roledefs = yaml.load(open('server_config.yaml').read())
 
 def status():
     """Gets status of all docker containers on server"""
-    run("docker ps")
+    run("docker ps -a")
 
 
 def update():

--- a/fabfile.py
+++ b/fabfile.py
@@ -14,8 +14,7 @@ from fabric.api import env, run
 #
 # You select the role to run with like s:
 #   $ fab -R role_name <command>
-host_types = yaml.load(open('server_config.yaml').read())
-env.roledefs = host_types
+env.roledefs = yaml.load(open('server_config.yaml').read())
 
 
 def status():

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,54 @@
+import os
+import yaml
+
+from fabric.api import env, run
+
+
+host_types = yaml.load(open('server_config.yaml').read())
+env.roledefs = host_types
+
+
+def status():
+    run("docker ps")
+
+
+def update():
+    if not env.effective_roles:
+        print("ERROR: You must specify a role when running this task. I.e. fab -R some-gpu task_name`")
+        return
+    if len(env.effective_roles) > 1:
+        print("ERROR: Only specify 1 role (because we need 1 broker_url) when running this task")
+        return
+
+    role = env.effective_roles[0]
+    broker_url = env.roledefs[role]["broker_url"]
+    is_gpu = env.roledefs[role]["is_gpu"]
+
+    if is_gpu:
+        docker_process = "nvidia-docker"
+        docker_image = "codalab/competitions-v2-compute-worker:nvidia"
+        nvidia_sock = "-v /var/lib/nvidia-docker/nvidia-docker.sock:/var/lib/nvidia-docker/nvidia-docker.sock"
+    else:
+        docker_process = "docker"
+        docker_image = "codalab/competitions-v2-compute-worker:latest"
+        nvidia_sock = ""
+
+    docker_command = f"""{docker_process} run \
+        -v /tmp/codalab-v2:/tmp/codalab-v2 \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        {nvidia_sock} \
+        -d \
+        --env BROKER_URL={broker_url} \
+        --restart unless-stopped \
+        --log-opt max-size=50m \
+        --log-opt max-file=3 \
+        {docker_image}
+    """
+
+    # Stop and remove containers
+    run("docker stop $(docker ps -aq)")
+    run("docker rm $(docker ps -aq)")
+
+    # Make sure we have latest image
+    run(f"docker pull {docker_image}")
+    run(f"{docker_command}")

--- a/server_config_sample.yaml
+++ b/server_config_sample.yaml
@@ -1,0 +1,14 @@
+comp-gpu:
+  hosts:
+    - ubuntu@12.34.56.78
+    - ubuntu@12.34.56.79
+  broker_url: pyamqp://user:pass@host:port/vhost-gpu
+  is_gpu: true
+  docker_image: codalab/competitions-v2-compute-worker:nvidia
+
+comp-cpu:
+  hosts:
+    - ubuntu@12.34.56.80
+  broker_url: pyamqp://user:pass@host:port/vhost-cpu
+  is_gpu: false
+  docker_image: codalab/competitions-v2-compute-worker:latest


### PR DESCRIPTION
# @ mention of reviewers
@jimmykodes 


# A brief description of the purpose of the changes contained in this PR.
Resolves #340 adding a script to maintain compute workers


# A checklist for hand testing
- [x] prereq: `pip install fab-classic` outside of docker, uses your SSH key on host machine
- [x] create `server_config.yaml` and add the gpus to it (I'll just send you this), run `fab -R autodl-gpu status`
- [ ] update some workers with `fab -R autodl-gpu update` _(may be overkill, can wait until we have relevant changes)_


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

