### PR TITLE
Fix excessive Detailed Results updates

### DIFF
--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -156,9 +156,17 @@
                 let event_data = JSON.parse(event.data)
                 switch (event_data.type) {
                     case 'catchup':
+                        let detailed_result_url = ''
                         _.forEach(_.compact(event_data.data.split('\n')), data => {
-                            self.handle_websocket(event_data.submission_id, JSON.parse(data))
+                            data = JSON.parse(data)
+                            if (data.kind === 'detailed_result_update') {
+                                detailed_result_url = data.result_url
+                            } else {
+                                self.handle_websocket(event_data.submission_id, JSON.parse(data), true)
+                            }
                         })
+                        self.detailed_result_urls[submission_id] = detailed_result_url
+                        self.update()
                         break
                     case 'message':
                         self.handle_websocket(event_data.submission_id, event_data.data)

--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -162,7 +162,7 @@
                             if (data.kind === 'detailed_result_update') {
                                 detailed_result_url = data.result_url
                             } else {
-                                self.handle_websocket(event_data.submission_id, JSON.parse(data))
+                                self.handle_websocket(event_data.submission_id, data)
                             }
                         })
                         self.detailed_result_urls[submission_id] = detailed_result_url

--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -162,7 +162,7 @@
                             if (data.kind === 'detailed_result_update') {
                                 detailed_result_url = data.result_url
                             } else {
-                                self.handle_websocket(event_data.submission_id, JSON.parse(data), true)
+                                self.handle_websocket(event_data.submission_id, JSON.parse(data))
                             }
                         })
                         self.detailed_result_urls[submission_id] = detailed_result_url


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 

# A brief description of the purpose of the changes contained in this PR.

Only updates the detailed results URL after all the lines of the catchup message have been addressed, so we only use the final URL. Should limit the number of detail_result.html calls from the frontend and speed up page refresh

# Issues this PR resolves
resolves #353 

# A checklist for hand testing
comp URL: http://134.158.74.226/competitions/53/#/participate-tab 
can download one of the already finished submissions from the submission table. 
- [x] run submission
- [x] wait for the graph to be updated a few times (so there are multiple detail_result updates in the tmp/.txt file
- [x] on refresh, should only be a few detailed results update calls (like 5ish depending on the timing of your refresh), instead of many


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

