### PR TITLE
349 submission child ordering

### DIFF
--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -249,7 +249,7 @@ def _run_submission(submission_pk, task_pk=None, is_scoring=False):
         "is_scoring": is_scoring,
     }
 
-    tasks = submission.phase.tasks.all()
+    tasks = submission.phase.tasks.all().order_by('pk')
     # TODO: Make the following code DRY!
     if task_pk is None:  # This is the initial submission object
         if len(tasks) > 1:

--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -324,9 +324,9 @@
             // stupid workaround to not modify the original submission object
             submission = _.defaultsDeep({}, submission)
             if (submission.has_children) {
-                submission.children = _.map(submission.children, child => {
+                submission.children = _.sortBy(_.map(submission.children, child => {
                     return {id: child}
-                })
+                }), 'id')
                 CODALAB.api.get_submission_details(submission.id)
                     .done(function (data) {
                         self.leaderboards = data.leaderboards

--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -134,7 +134,7 @@
                      class="ui tab"
                      data-tab="{admin_: is_admin()}child_{i}">
                     <submission-modal hide_output="{selected_phase.hide_output}"
-                                      show_graph="{opts.competition.enable_detailed_results}" 
+                                      show_graph="{opts.competition.enable_detailed_results}"
                                       submission="{child}"></submission-modal>
                 </div>
                 <div class="ui tab" style="height: 565px; overflow: auto;" data-tab="admin" if="{is_admin()}">
@@ -324,9 +324,9 @@
             // stupid workaround to not modify the original submission object
             submission = _.defaultsDeep({}, submission)
             if (submission.has_children) {
-                submission.children = _.sortBy(_.map(submission.children, child => {
+                submission.children = _.map(_.sortBy(submission.children), child => {
                     return {id: child}
-                }), 'id')
+                })
                 CODALAB.api.get_submission_details(submission.id)
                     .done(function (data) {
                         self.leaderboards = data.leaderboards


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 

# A brief description of the purpose of the changes contained in this PR.
adds a test verifying that submission children ids and task ids are always created in ascending order
ie:
child id: 24 => task id: 12
child id: 25 => task id: 22

so that the nth child is always run against the nth task as sorted by PKs

# Issues this PR resolves
resolves #349 

# A checklist for hand testing
- [x] upload supplied competition 
- [x] run a submission through the competition
- [x] the child submission with the lowest pk should be run against the task w/ the lowest pk
- [x] this should stay the same across multiple runs.
- [x] when viewing the submission details (by clicking a row in the submission table) the order of submissions there should be the same as it was in the streaming output

# Any relevant files for testing
[competition file](https://github.com/codalab/competitions-v2/files/4258164/old_autodl.zip)
[submission file](https://github.com/codalab/competitions-v2/files/4258004/autodl_sub.zip)


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

