### PR TITLE
Execution Time Limit Fixes

### DIFF
--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -615,13 +615,13 @@ class Run:
                     elapsed_time = self.execution_time_limit
                 return_code = logs["proc"].returncode
                 if return_code is None:
-                    # procedure is still running, kill it
                     logger.info('No return code from Process. Killing it')
                     if kind == 'ingestion':
                         program_to_kill = self.ingestion_container_name
                     else:
                         program_to_kill = self.program_container_name
-                    kill_code = subprocess.call(['docker', 'kill', str(program_to_kill)])
+                    # Try and stop the program. If stop does not succeed
+                    kill_code = subprocess.call(['docker', 'stop', str(program_to_kill)])
                     logger.info(f'Kill process returned {kill_code}')
                 if kind == 'program':
                     self.program_exit_code = return_code

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -530,7 +530,7 @@ def create_competition_dump(competition_pk, keys_instead_of_files=True):
                     elif field == 'max_submissions_per_person':
                         temp_phase_data['max_submissions'] = getattr(phase, field)
                     elif field == 'execution_time_limit':
-                        temp_phase_data['execution_time_limit_ms'] = getattr(phase, field)
+                        temp_phase_data['execution_time_limit'] = getattr(phase, field)
                     else:
                         temp_phase_data[field] = getattr(phase, field, "")
             task_indexes = [task_solution_pairs[task.id]['index'] for task in phase.tasks.all()]

--- a/src/apps/competitions/tests/unpacker_test_data.py
+++ b/src/apps/competitions/tests/unpacker_test_data.py
@@ -103,7 +103,7 @@ v2_yaml_data = {
         {
             "name": "Development Phase",
             "description": "Development phase",
-            "execution_time_limit_ms": 500,
+            "execution_time_limit": 500,
             "max_submissions_per_day": 5,
             "start": "2019-01-01",
             "end": "2019-09-30",
@@ -112,7 +112,7 @@ v2_yaml_data = {
         {
             "name": "Final Phase",
             "description": "Final phase",
-            "execution_time_limit_ms": 300,
+            "execution_time_limit": 300,
             "max_submissions_per_day": 5,
             "auto_migrate_to_this_phase": True,
             "start": "2019-09-30",

--- a/src/apps/competitions/unpackers/v2.py
+++ b/src/apps/competitions/unpackers/v2.py
@@ -192,7 +192,7 @@ class V2Unpacker(BaseUnpacker):
             except KeyError:
                 raise CompetitionUnpackingException(f'Phases must contain at least one task to be valid')
 
-            execution_time_limit = phase_data.get('execution_time_limit_ms')
+            execution_time_limit = phase_data.get('execution_time_limit')
             if execution_time_limit:
                 new_phase['execution_time_limit'] = execution_time_limit
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -84,12 +84,11 @@
                                     <a class="item" href="{% url "pages:server_status" %}">Server Status</a>
                                     <a class="item" href="{% url "admin:index" %}">Django admin</a>
                                     <a class="item" href="{% url "analytics:analytics" %}">Analytics</a>
-                                    <a class="item" href="{% url "queues:management" %}">Queues</a>
 {#                                    <a class="item" href="#">Health</a>#}
 {#                                    <a class="item" href="#">Users</a>#}
 {#                                    <a class="item" href="#">Submissions</a>#}
-                                    <a class="item" href="#" onclick="$('#user_switch_modal').modal('show')">Switch
-                                        User</a>
+{#                                    <a class="item" href="#" onclick="$('#user_switch_modal').modal('show')">Switch#}
+{#                                        User</a>#}
                                 {% endif %}
                                 <div class="ui divider"></div>
                                 <div class="header">Account</div>


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
Fixes references to execution time limit as _ms since the actual unit is seconds.
Should address uploading a comp, and creating a dump.
Also actually times out ingestion/scoring programs and writes their logs.

Also removes redundant buttons in user dropdown. Not strictly related to this PR, but since it is small and needed to be done, addressing it here rather than creating a new PR.

# Issues this PR resolves
Resolves #366 
wrong number in the branch name... oops.
resolves #374 

# A checklist for hand testing
- [x] upload a competition, and set its phase's execution time limit to something like 10 seconds.
- [x] upload a submission with a sleep of that length contained in it.
- [x] submission should terminate and the docker container should be removed.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

