### PR TITLE
Competition Dump Fixes

### DIFF
--- a/src/apps/api/views/tasks.py
+++ b/src/apps/api/views/tasks.py
@@ -49,7 +49,7 @@ class TaskViewSet(ModelViewSet):
             # We have to grab something from task_validate_qs here, so i grab pk
             qs = qs.annotate(validated=Subquery(task_validate_qs.values('pk')[:1]))
 
-        return qs.order_by('-created_when')
+        return qs.order_by('-created_when').distinct()
 
     def get_serializer_class(self):
         if self.request.method == 'GET':

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -34,6 +34,7 @@ COMPETITION_FIELDS = [
     "title",
     "docker_image",
     "queue",
+    "description",
     "registration_auto_approve",
     "enable_detailed_results"
 ]
@@ -60,6 +61,8 @@ PHASE_FIELDS = [
     'max_submissions_per_day',
     'max_submissions_per_person',
     'execution_time_limit',
+    'auto_migrate_to_this_phase',
+    'hide_output',
 ]
 PHASE_FILES = [
     "input_data",
@@ -75,6 +78,7 @@ PAGE_FIELDS = [
 LEADERBOARD_FIELDS = [
     'title',
     'key',
+    'hidden',
 
     # For later
     # 'force_submission_to_leaderboard',
@@ -89,7 +93,7 @@ COLUMN_FIELDS = [
     'sorting',
     'computation',
     'computation_indexes',
-    'decimal_count',
+    'hidden',
 ]
 
 
@@ -404,7 +408,7 @@ def create_competition_dump(competition_pk, keys_instead_of_files=True):
         for field in COMPETITION_FIELDS:
             if hasattr(comp, field):
                 value = getattr(comp, field, "")
-                if field == 'queue':
+                if field == 'queue' and value is not None:
                     value = str(value.vhost)
                 yaml_data[field] = value
         if comp.logo:
@@ -539,12 +543,10 @@ def create_competition_dump(competition_pk, keys_instead_of_files=True):
                         temp_date = getattr(phase, field)
                         if not temp_date:
                             continue
-                        temp_date = temp_date.strftime("%m-%d-%Y")
+                        temp_date = temp_date.strftime("%Y-%m-%d")
                         temp_phase_data[field] = temp_date
                     elif field == 'max_submissions_per_person':
                         temp_phase_data['max_submissions'] = getattr(phase, field)
-                    elif field == 'execution_time_limit':
-                        temp_phase_data['execution_time_limit_ms'] = getattr(phase, field)
                     else:
                         temp_phase_data[field] = getattr(phase, field, "")
             task_indexes = [task_solution_pairs[task.id]['index'] for task in phase.tasks.all()]

--- a/src/apps/competitions/tests/test_v15_unpacker.py
+++ b/src/apps/competitions/tests/test_v15_unpacker.py
@@ -25,7 +25,7 @@ class V15UnpackerTests(TestCase):
 
     def test_phase_unpacking(self):
         self.unpacker._unpack_phases()
-        assert self.unpacker.competition['phases'] == test_data.PHASES
+        assert self.unpacker.competition['phases'] == test_data.PHASES1
 
     def test_page_unpacking(self):
         self.unpacker._unpack_pages()

--- a/src/apps/competitions/tests/test_v15_unpacker.py
+++ b/src/apps/competitions/tests/test_v15_unpacker.py
@@ -25,7 +25,7 @@ class V15UnpackerTests(TestCase):
 
     def test_phase_unpacking(self):
         self.unpacker._unpack_phases()
-        assert self.unpacker.competition['phases'] == test_data.PHASES1
+        assert self.unpacker.competition['phases'] == test_data.get_phases(1)
 
     def test_page_unpacking(self):
         self.unpacker._unpack_pages()

--- a/src/apps/competitions/tests/test_v2_unpacker.py
+++ b/src/apps/competitions/tests/test_v2_unpacker.py
@@ -25,7 +25,7 @@ class V2UnpackerTests(TestCase):
 
     def test_phase_unpacking(self):
         self.unpacker._unpack_phases()
-        assert self.unpacker.competition['phases'] == test_data.PHASES
+        assert self.unpacker.competition['phases'] == test_data.PHASES2
 
     def test_terms_unpacking(self):
         self.unpacker._unpack_terms()

--- a/src/apps/competitions/tests/test_v2_unpacker.py
+++ b/src/apps/competitions/tests/test_v2_unpacker.py
@@ -25,7 +25,7 @@ class V2UnpackerTests(TestCase):
 
     def test_phase_unpacking(self):
         self.unpacker._unpack_phases()
-        assert self.unpacker.competition['phases'] == test_data.PHASES2
+        assert self.unpacker.competition['phases'] == test_data.get_phases(2)
 
     def test_terms_unpacking(self):
         self.unpacker._unpack_terms()

--- a/src/apps/competitions/tests/unpacker_test_data.py
+++ b/src/apps/competitions/tests/unpacker_test_data.py
@@ -169,7 +169,7 @@ PAGES = [{
 }]
 TERMS = 'Placeholder terms content for testing\n'
 
-PHASES1 = [
+PHASES = [
     {
         'index': 0,
         'start': datetime.datetime(2019, 1, 1, 0, 0, tzinfo=timezone.now().tzinfo),
@@ -200,38 +200,23 @@ PHASES1 = [
     }
 ]
 
-PHASES2 = [
-    {
-        'index': 0,
-        'start': datetime.datetime(2019, 1, 1, 0, 0, tzinfo=timezone.now().tzinfo),
-        'name': 'Development Phase',
-        'description': 'Development phase',
-        'execution_time_limit': 500,
-        'max_submissions_per_day': 5,
-        'max_submissions_per_person': None,
-        'auto_migrate_to_this_phase': False,
-        'has_max_submissions': True,
-        'hide_output': False,
-        'end': datetime.datetime(2019, 9, 30, 0, 0, tzinfo=timezone.now().tzinfo),
-        'tasks': [0],
-        'status': 'Previous'
-    },
-    {
-        'index': 1,
-        'start': datetime.datetime(2019, 9, 30, 0, 0, tzinfo=timezone.now().tzinfo),
-        'name': 'Final Phase',
-        'description': 'Final phase',
-        'execution_time_limit': 300,
-        'max_submissions_per_day': 5,
-        'max_submissions_per_person': None,
-        'auto_migrate_to_this_phase': True,
-        'has_max_submissions': True,
-        'hide_output': False,
-        'tasks': [1],
-        'status': 'Current',
-        'end': None
-    }
+V2_SPECIFIC_PHASE_DATA = [
+    # Tuples of (key, value) of data specific to v2 unpacker.
+    ('hide_output', False)
 ]
+
+
+def get_phases(version):
+    if version == 1:
+        return PHASES
+    elif version == 2:
+        # Make a copy of the list so we aren't mutating the original phases object. May not be strictly necessary,
+        # but if we ever write a test comparing v1 to v2 or something, this would avoid bugs.
+        v2 = [{k: v for k, v in phase.items()} for phase in PHASES]
+        for phase in v2:
+            for key, value in V2_SPECIFIC_PHASE_DATA:
+                phase[key] = value
+        return v2
 
 
 def get_tasks(user_id):

--- a/src/apps/competitions/tests/unpacker_test_data.py
+++ b/src/apps/competitions/tests/unpacker_test_data.py
@@ -180,6 +180,7 @@ PHASES = [
         'max_submissions_per_person': None,
         'auto_migrate_to_this_phase': False,
         'has_max_submissions': True,
+        'hide_output': False,
         'end': datetime.datetime(2019, 9, 30, 0, 0, tzinfo=timezone.now().tzinfo),
         'tasks': [0],
         'status': 'Previous'
@@ -194,6 +195,7 @@ PHASES = [
         'max_submissions_per_person': None,
         'auto_migrate_to_this_phase': True,
         'has_max_submissions': True,
+        'hide_output': False,
         'tasks': [1],
         'status': 'Current',
         'end': None

--- a/src/apps/competitions/tests/unpacker_test_data.py
+++ b/src/apps/competitions/tests/unpacker_test_data.py
@@ -169,7 +169,38 @@ PAGES = [{
 }]
 TERMS = 'Placeholder terms content for testing\n'
 
-PHASES = [
+PHASES1 = [
+    {
+        'index': 0,
+        'start': datetime.datetime(2019, 1, 1, 0, 0, tzinfo=timezone.now().tzinfo),
+        'name': 'Development Phase',
+        'description': 'Development phase',
+        'execution_time_limit': 500,
+        'max_submissions_per_day': 5,
+        'max_submissions_per_person': None,
+        'auto_migrate_to_this_phase': False,
+        'has_max_submissions': True,
+        'end': datetime.datetime(2019, 9, 30, 0, 0, tzinfo=timezone.now().tzinfo),
+        'tasks': [0],
+        'status': 'Previous'
+    },
+    {
+        'index': 1,
+        'start': datetime.datetime(2019, 9, 30, 0, 0, tzinfo=timezone.now().tzinfo),
+        'name': 'Final Phase',
+        'description': 'Final phase',
+        'execution_time_limit': 300,
+        'max_submissions_per_day': 5,
+        'max_submissions_per_person': None,
+        'auto_migrate_to_this_phase': True,
+        'has_max_submissions': True,
+        'tasks': [1],
+        'status': 'Current',
+        'end': None
+    }
+]
+
+PHASES2 = [
     {
         'index': 0,
         'start': datetime.datetime(2019, 1, 1, 0, 0, tzinfo=timezone.now().tzinfo),

--- a/src/apps/competitions/unpackers/base_unpacker.py
+++ b/src/apps/competitions/unpackers/base_unpacker.py
@@ -263,7 +263,7 @@ class BaseUnpacker:
                         continue
                     key, temp_data_path = self._get_data_key(**task_file_data)
                     task[file_type] = key
-                # TODO: Pass created_by explicitly here instead of request
+                # because created_by is a read only field, we need to grab it from the context and can't pass it in data
                 serializer = TaskSerializer(data=task, context={'request': self.fake_request})
                 serializer.is_valid(raise_exception=True)
                 new_task = serializer.save()
@@ -287,6 +287,7 @@ class BaseUnpacker:
                 solution['data'], temp_data_path = self._get_data_key(**solution, file_type='solution')
                 if temp_data_path:
                     solution['md5'] = md5(temp_data_path)
+                # because created_by is a read only field, we need to grab it from the context and can't pass it in data
                 serializer = SolutionSerializer(data=solution, context={'request': self.fake_request})
                 serializer.is_valid(raise_exception=True)
                 new_solution = serializer.save()

--- a/src/apps/competitions/unpackers/base_unpacker.py
+++ b/src/apps/competitions/unpackers/base_unpacker.py
@@ -263,6 +263,7 @@ class BaseUnpacker:
                         continue
                     key, temp_data_path = self._get_data_key(**task_file_data)
                     task[file_type] = key
+                # TODO: Pass created_by explicitly here instead of request
                 serializer = TaskSerializer(data=task, context={'request': self.fake_request})
                 serializer.is_valid(raise_exception=True)
                 new_task = serializer.save()

--- a/src/apps/competitions/unpackers/base_unpacker.py
+++ b/src/apps/competitions/unpackers/base_unpacker.py
@@ -275,10 +275,13 @@ class BaseUnpacker:
             if 'key' in solution:
                 try:
                     s = Solution.objects.get(key=solution['key'])
+                    solution_tasks = s.tasks.all().values_list('pk', flat=True)
                 except Solution.DoesNotExist:
                     raise CompetitionUnpackingException(f'Could not find solution with key: {solution["key"]}')
                 for task_index in solution['tasks']:
-                    s.add(self.competition['tasks'][task_index])
+                    task = self.competition['tasks'][task_index]
+                    if task.id not in solution_tasks:
+                        s.tasks.add(task)
             else:
                 solution['tasks'] = [self.competition['tasks'][index].key for index in solution['tasks']]
                 solution['data'], temp_data_path = self._get_data_key(**solution, file_type='solution')

--- a/src/apps/competitions/unpackers/v1.py
+++ b/src/apps/competitions/unpackers/v1.py
@@ -17,6 +17,7 @@ class V15Unpacker(BaseUnpacker):
             "title": self.competition_yaml.get('title'),
             "logo": None,
             "registration_auto_approve": not self.competition_yaml.get('has_registration', True),
+            "description": self.competition_yaml.get("description", ""),
             "docker_image": docker_image,
             "enable_detailed_results": self.competition_yaml.get('enable_detailed_results', False),
             "pages": [],

--- a/src/apps/competitions/unpackers/v2.py
+++ b/src/apps/competitions/unpackers/v2.py
@@ -15,6 +15,7 @@ class V2Unpacker(BaseUnpacker):
             "registration_auto_approve": self.competition_yaml.get('registration_auto_approve', False),
             "docker_image": self.competition_yaml.get('docker_image', 'codalab/codalab-legacy:py3'),
             "enable_detailed_results": self.competition_yaml.get('enable_detailed_results', False),
+            "description": self.competition_yaml.get("description", ""),
             "pages": [],
             "phases": [],
             "leaderboards": [],
@@ -186,6 +187,7 @@ class V2Unpacker(BaseUnpacker):
                 'max_submissions_per_day': phase_data.get('max_submissions_per_day'),
                 'max_submissions_per_person': phase_data.get('max_submissions'),
                 'auto_migrate_to_this_phase': phase_data.get('auto_migrate_to_this_phase', False),
+                'hide_output': phase_data.get('hide_output', False),
             }
             try:
                 new_phase['tasks'] = phase_data['tasks']


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
adding fixes so that a re-uploaded dump will create the same competition it was dumped from. Add the appropriate fields for this, and also output dataset keys instead of zipping the entire dataset, cause a memory exceeded error from celery



# Issues this PR resolves
resolves #369 
resolves #379 


# Known issues to be addressed in a separate PR
Does not address the contents of #370 


# A checklist for hand testing
- [ ] upload a competition of your choosing
- [ ] create a dump of that competition
- [ ] download and re-upload the dump zip and verify the competition is the same


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

