### PR TITLE
added toastr instead of modal on ux dump

### DIFF
--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -176,7 +176,7 @@
                 .done(data => {
                     self.tr_show = true
                     toastr.success("Success! Your competition dump is being created.")
-                    setTimeout(self.update_files, 100)
+                    self.update()
                 })
                 .fail(response => {
                     toastr.error("Error trying to create competition dump.")
@@ -187,9 +187,8 @@
             CODALAB.api.get_competition_files(self.competition.id)
                 .done(data => {
                     self.files = data
+                    self.tr_show = false
                     self.update()
-
-                    this.tr_show = false
 
                     if (e) {
                         // Only display toast if activated from button, not CODALAB.event

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -115,6 +115,7 @@
     </div>
 
     <!-- Manage Participants Modal -->
+    <!--
     <div class="ui manage-participants modal" ref="participant_modal">
         <div class="content">
             <participant-manager></participant-manager>
@@ -133,6 +134,7 @@
             <div class="ui primary inverted ok button">Dismiss</div>
         </div>
     </div>
+    -->
 
     <!-- Manual Migration Modal -->
     <div class="ui migration modal" ref="migration_modal">
@@ -182,8 +184,9 @@
         self.create_dump = () => {
             CODALAB.api.create_dump(self.competition.id)
                 .done(data => {
-                    $(self.refs.dump_modal).modal('show')
-                    setTimeout(self.update_files, 2000)
+                    toastr.success("Success! Your competition dump is being created.")
+                    //$(self.refs.dump_modal).modal('show')
+                    //setTimeout(self.update_files, 2000)
                 })
                 .fail(response => {
                     toastr.error("Error trying to create competition dump.")

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -156,7 +156,7 @@
         self.competition = {}
         self.files = []
 
-        self.tr_show= false
+        self.tr_show = false
 
         CODALAB.events.on('competition_loaded', function (competition) {
             competition.admin = CODALAB.state.user.has_competition_admin_privileges(competition)

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -115,26 +115,11 @@
     </div>
 
     <!-- Manage Participants Modal -->
-    <!--
     <div class="ui manage-participants modal" ref="participant_modal">
         <div class="content">
             <participant-manager></participant-manager>
         </div>
     </div>
-
-    <div class="ui basic modal" ref="dump_modal">
-        <div class="header">
-            Creating Competition Dump
-        </div>
-        <div class="content">
-            Success! Your competition dump is being created. This may take some time.
-            If the files table does not update with the new dump, try refreshing the table.
-        </div>
-        <div class="actions">
-            <div class="ui primary inverted ok button">Dismiss</div>
-        </div>
-    </div>
-    -->
 
     <!-- Manual Migration Modal -->
     <div class="ui migration modal" ref="migration_modal">
@@ -185,8 +170,7 @@
             CODALAB.api.create_dump(self.competition.id)
                 .done(data => {
                     toastr.success("Success! Your competition dump is being created.")
-                    //$(self.refs.dump_modal).modal('show')
-                    //setTimeout(self.update_files, 2000)
+                    setTimeout(self.update_files, 2000)
                 })
                 .fail(response => {
                     toastr.error("Error trying to create competition dump.")

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -80,9 +80,6 @@
                 <tr>
                     <th>Files</th>
                 </tr>
-                <tr>
-                    <th if="{tr_show}">Generating Dump, Please Refresh</th>
-                </tr>
                 </thead>
                 <tbody>
                 <tr show="{files.bundle}">
@@ -105,6 +102,9 @@
                     <td show="{!files.dumps && !files.bundle}">
                         <em>No Files Yet</em>
                     </td>
+                </tr>
+                <tr>
+                    <td class="dump-td" if="{tr_show}">Generating Dump, Please Refresh</td>
                 </tr>
                 </tbody>
             </table>
@@ -274,6 +274,9 @@
             border-bottom 1px solid $teal
             display inline-block
             line-height 0.9em
+
+        .dump-td
+            text-align center !important
 
         .tiny.left.labeled.button
             display flex

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -80,6 +80,9 @@
                 <tr>
                     <th>Files</th>
                 </tr>
+                <tr>
+                    <th if="{tr_show}">Generating Dump, Please Refresh</th>
+                </tr>
                 </thead>
                 <tbody>
                 <tr show="{files.bundle}">
@@ -153,6 +156,8 @@
         self.competition = {}
         self.files = []
 
+        self.tr_show= false
+
         CODALAB.events.on('competition_loaded', function (competition) {
             competition.admin = CODALAB.state.user.has_competition_admin_privileges(competition)
             self.competition = competition
@@ -169,8 +174,9 @@
         self.create_dump = () => {
             CODALAB.api.create_dump(self.competition.id)
                 .done(data => {
+                    self.tr_show = true
                     toastr.success("Success! Your competition dump is being created.")
-                    setTimeout(self.update_files, 2000)
+                    setTimeout(self.update_files, 100)
                 })
                 .fail(response => {
                     toastr.error("Error trying to create competition dump.")
@@ -182,6 +188,9 @@
                 .done(data => {
                     self.files = data
                     self.update()
+
+                    this.tr_show = false
+
                     if (e) {
                         // Only display toast if activated from button, not CODALAB.event
                         toastr.success('Table Updated')

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -104,7 +104,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <td class="dump-td" if="{tr_show}">Generating Dump, Please Refresh</td>
+                    <td class="center aligned" if="{tr_show}">Generating Dump, Please Refresh</td>
                 </tr>
                 </tbody>
             </table>
@@ -274,9 +274,6 @@
             border-bottom 1px solid $teal
             display inline-block
             line-height 0.9em
-
-        .dump-td
-            text-align center !important
 
         .tiny.left.labeled.button
             display flex


### PR DESCRIPTION

# @ mention of reviewers
@jimmykodes @ckcollab 

# A brief description of the purpose of the changes contained in this PR.
Changed the Modal to a Toastr message once dump has been successful. 


# Issues this PR resolves
resolves #389

# Misc. comments
I think I did what was needed but just incase i left the code commented to make sure I can revert and adjust


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

