### PR TITLE
Editor fixes

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -111,9 +111,9 @@
                                  data-tab="_tab_page{page.index}">
                                 { page.title }
                             </div>
-                            <div class="{active: _.get(competition.pages, 'length') === 0} item" data-tab="files">
+                            <!--<div class="{active: _.get(competition.pages, 'length') === 0} item" data-tab="files">
                                 Files
-                            </div>
+                            </div>-->
                         </div>
                     </div>
                     <div class="twelve wide column">
@@ -122,7 +122,7 @@
                             <div class="ui" id="page_{i}">
                             </div>
                         </div>
-                        <div class="ui tab {active: _.get(competition.pages, 'length') === 0}" data-tab="files">
+                        <!--<div class="ui tab {active: _.get(competition.pages, 'length') === 0}" data-tab="files">
                             <div class="ui" id="files">
                                 <table class="ui celled table">
                                     <thead>
@@ -148,7 +148,7 @@
                                 </table>
 
                             </div>
-                        </div>
+                        </div>-->
                     </div>
                 </div>
             </div>

--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -118,7 +118,7 @@
         <div class="content">
             <div if="{!!selected_submission && !_.get(selected_submission, 'has_children', false)}">
                 <submission-modal hide_output="{selected_phase.hide_output}"
-                                  show_graph="{opts.competition.enable_detailed_results}"
+                                  show_visualization="{opts.competition.enable_detailed_results}"
                                   submission="{selected_submission}"></submission-modal>
             </div>
             <div if="{!!selected_submission && _.get(selected_submission, 'has_children', false)}">
@@ -134,7 +134,7 @@
                      class="ui tab"
                      data-tab="{admin_: is_admin()}child_{i}">
                     <submission-modal hide_output="{selected_phase.hide_output}"
-                                      show_graph="{opts.competition.enable_detailed_results}"
+                                      show_visualization="{opts.competition.enable_detailed_results}"
                                       submission="{child}"></submission-modal>
                 </div>
                 <div class="ui tab" style="height: 565px; overflow: auto;" data-tab="admin" if="{is_admin()}">

--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -42,7 +42,7 @@
             <th>File name</th>
             <th if="{ opts.admin }">Owner</th>
             <th if="{ opts.admin }">Phase</th>
-            <th class="right aligned status-column">Status</th>
+            <th class="right aligned">Status</th>
             <th class="center aligned {admin-action-column: opts.admin, action-column: !opts.admin}">Actions</th>
         </tr>
         </thead>
@@ -61,7 +61,7 @@
             <td>{ submission.filename }</td>
             <td if="{ opts.admin }">{ submission.owner }</td>
             <td if="{ opts.admin }">{ submission.phase.name }</td>
-            <td class="right aligned">
+            <td class="right aligned collapsing">
                 { submission.status }
                 <sup data-tooltip="{submission.status_details}">
                     <i if="{submission.status === 'Failed'}" class="failed question circle icon"></i>
@@ -408,9 +408,6 @@
 
         .action-column
             width 100px
-
-        .status-column
-            width 50px
 
         .submission_row
             &:hover

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -2,7 +2,7 @@
     <div class="ui large green pointing menu">
         <div class="active submission-modal item" data-tab="{admin_: submission.admin}downloads">DOWNLOADS</div>
         <div class="submission-modal item" data-tab="{admin_: submission.admin}logs" show="{!opts.hide_output}">LOGS</div>
-        <div class="submission-modal item" data-tab="{admin_: submission.admin}graph" show="{!opts.hide_output && opts.show_graph}">GRAPH</div>
+        <div class="submission-modal item" data-tab="{admin_: submission.admin}graph" show="{!opts.hide_output && opts.show_visualization}">VISUALIZATION</div>
         <div class="submission-modal item" data-tab="admin" if="{submission.admin}">ADMIN</div>
     </div>
     <div class="ui tab active modal-tab" data-tab="{admin_: submission.admin}downloads">
@@ -128,7 +128,7 @@
             </div>
         </div>
     </div>
-    <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}graph" show="{opts.show_graph && (!opts.hide_output || submission.admin)}">
+    <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}graph" show="{opts.show_visualization && (!opts.hide_output || submission.admin)}">
         <iframe src="{detailed_result}" class="graph-frame" show="{detailed_result}"></iframe>
     </div>
     <div class="ui tab leaderboard-tab" data-tab="admin" if="{submission.admin}">

--- a/src/static/riot/competitions/editor/_collaborators.tag
+++ b/src/static/riot/competitions/editor/_collaborators.tag
@@ -27,7 +27,7 @@
                     <tr>
                         <th colspan="2" class="right aligned">
                             <button class="ui tiny inverted green icon button" ref="modal_button">
-                                <i class="add icon"></i> Add collaborator
+                                <i class="add icon"></i> Add administrator
                             </button>
                         </th>
                     </tr>

--- a/src/static/riot/competitions/editor/_collaborators.tag
+++ b/src/static/riot/competitions/editor/_collaborators.tag
@@ -5,10 +5,14 @@
                 <table class="ui padded table">
                     <thead>
                     <tr>
-                        <th colspan="2">Collaborators</th>
+                        <th colspan="2">Administrators</th>
                     </tr>
                     </thead>
                     <tbody>
+                    <tr>
+                        <td>{created_by}</td>
+                        <td class="right aligned">Creator</td>
+                    </tr>
                     <tr each="{collab, index in collabs}">
                         <td>{collab.name || collab.username}</td>
                         <td class="right aligned">
@@ -16,11 +20,6 @@
                                onclick="{ remove_collaborator.bind(this, index, (collab.name || collab.username)) }">
                                 <i class="red trash alternate outline icon"></i>
                             </a>
-                        </td>
-                    </tr>
-                    <tr show="{collabs.length === 0}">
-                        <td colspan="2" class="center aligned">
-                            <em>No collaborators yet!</em>
                         </td>
                     </tr>
                     </tbody>

--- a/src/static/riot/competitions/editor/_competition_details.tag
+++ b/src/static/riot/competitions/editor/_competition_details.tag
@@ -39,11 +39,13 @@
                 <label>Enable Visualizations</label>
                 <input type="checkbox" ref="detailed_results">
             </div>
-            <a href="https://github.com/codalab/competitions-v2/wiki/Detailed-Results-and-Visualizations"
-               target="_blank"
-               data-tooltip="What's this?">
-                <i class="small grey circular question mark icon"></i>
-            </a>
+            <sup>
+                <a href="https://github.com/codalab/competitions-v2/wiki/Detailed-Results-and-Visualizations"
+                   target="_blank"
+                   data-tooltip="What's this?">
+                    <i class="grey question circle icon"></i>
+                </a>
+            </sup>
         </div>
     </div>
 

--- a/src/static/riot/competitions/editor/_competition_details.tag
+++ b/src/static/riot/competitions/editor/_competition_details.tag
@@ -10,7 +10,7 @@
             <!-- This is the SINGLE FILE with NO OTHER OPTIONS example -->
             <!-- In the future, we'll have this type AND a type that is pre-filled with nice options -->
             <label show="{ uploaded_logo }">
-                Uploaded Logo: <a href="{ uploaded_logo }">{ uploaded_logo_name }</a>
+                Uploaded Logo: <a href="{ uploaded_logo }" target="_blank">{ uploaded_logo_name }</a>
             </label>
             <div class="ui left action file input">
                 <button class="ui icon button" onclick="document.getElementById('form_file_logo').click()">
@@ -36,9 +36,14 @@
         </div>
         <div class="field">
             <div class="ui checkbox">
-                <label>Enable Detailed Results</label>
+                <label>Enable Visualizations</label>
                 <input type="checkbox" ref="detailed_results">
             </div>
+            <a href="https://github.com/codalab/competitions-v2/wiki/Detailed-Results-and-Visualizations"
+               target="_blank"
+               data-tooltip="What's this?">
+                <i class="small grey circular question mark icon"></i>
+            </a>
         </div>
     </div>
 

--- a/src/static/riot/competitions/editor/form.tag
+++ b/src/static/riot/competitions/editor/form.tag
@@ -60,7 +60,7 @@
                     <a class="item" data-tab="collaborators">
                         <i class="checkmark box icon green" show="{ valid_sections.collaborators && !errors.collaborators }"></i>
                         <i class="minus circle icon red" show="{ errors.collaborators }"></i>
-                        Collaborators
+                        Administrators
                     </a>
                 </div>
                 <div class="ui active tab" data-tab="competition_details">

--- a/src/static/riot/competitions/editor/form.tag
+++ b/src/static/riot/competitions/editor/form.tag
@@ -86,18 +86,18 @@
 
         <div class="center aligned row">
             <div class="column">
-                <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
-                <button class="ui primary button { disabled: !are_all_sections_valid() }"
-                        onclick="{ save_and_publish }">
-                    Save and Publish
-                </button>
-                <button class="ui grey button { disabled: !are_all_sections_valid() }" onclick="{ save_as_draft }">
-                    Save as Draft
+                <div class="ui checkbox publish-checkbox">
+                    <input type="checkbox" ref="publish">
+                    <label>Publish</label>
+                </div>
+                <button class="ui primary button { disabled: !are_all_sections_valid() }" onclick="{ save }">
+                    Save
                 </button>
                 <button class="ui basic red button discard" onclick="{ discard }">
                     Discard Changes
                 </button>
                 <a class="ui secondary basic button" href="{URLS.COMPETITION_DETAIL(opts.competition_id)}">Back To Competition</a>
+                <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
             </div>
         </div>
     </div>
@@ -149,6 +149,7 @@
             CODALAB.api.get_competition(id)
                 .done(function (data) {
                     self.competition = data
+                    self.refs.publish.checked = self.competition.published
                     CODALAB.events.trigger('competition_loaded', self.competition)
                     self.update()
                 })
@@ -168,7 +169,8 @@
             }
         }
 
-        self._save = function (publish) {
+        self.save = function () {
+            self.competition.published = self.refs.publish.checked
             let previous_index, current_index, next_index;
             let now = new Date()
 
@@ -222,14 +224,8 @@
                 .done(function (response) {
                     self.errors = {}
                     self.update()
-                    if (publish) {
-                        toastr.success("Competition published!")
-                        window.location.href = window.URLS.COMPETITION_DETAIL(response.id)
-                    } else {
-                        toastr.success("Competition saved!")
-                        self.competition = response
-                        CODALAB.events.trigger('competition_loaded', self.competition)
-                    }
+                    toastr.success("Competition saved!")
+                    window.location.href = window.URLS.COMPETITION_DETAIL(response.id)
                 })
                 .fail(function (response) {
                     if (response) {
@@ -258,17 +254,6 @@
                 })
 
         }
-
-        self.save_and_publish = () => {
-            self.competition.published = true
-            self._save(self.competition.published)
-        }
-
-        self.save_as_draft = () => {
-            self.competition.published = false
-            self._save(self.competition.published)
-        }
-
         /*---------------------------------------------------------------------
          Events
         ---------------------------------------------------------------------*/
@@ -282,6 +267,8 @@
         })
     </script>
     <style type="text/stylus">
+        .publish-checkbox
+            margin-right 10px
         .ui.basic.red.button.discard:hover
             background-color #db2828 !important
             color white !important


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
A handful of updates to the editor.


# Issues this PR resolves
resolves #393 
resolves #394 
resolves #395 
resolves #396 

# A checklist for hand testing
- [x] Checking or unchecking the Publish checkbox in the editor should change whether a competition is published on save.
- [x] Clicking save should always take you back to the comp detail page
- [x] Enable Detailed results now says "Enable Visualizations"
- [x] GRAPH section of submission detail modals should say "VISUALIZATION" instead
- [x] viewing the uploaded logo of a competition should open the image in a new tab, rather than navigate away from the page. 
- [x] Files section on competition detail page is now hidden.
- [x] changed references to collaborators in the editor to be "administrator"



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

