### PR TITLE
Non-phase dependent leaderboard submission add fixed.

### DIFF
--- a/src/apps/api/views/leaderboards.py
+++ b/src/apps/api/views/leaderboards.py
@@ -47,7 +47,7 @@ def add_submission_to_leaderboard(request, submission_pk):
     submission = get_object_or_404(Submission, pk=submission_pk)
 
     # Removing any existing submissions on leaderboard
-    submission.phase.submissions.filter(owner=request.user).exclude(leaderboard=None).update(leaderboard=None)
+    Submission.objects.filter(phase__competition=submission.phase.competition).filter(owner=request.user).exclude(leaderboard=None).update(leaderboard=None)
 
     # toggle submission on or off, if it was already on leaderboard
     if not submission.leaderboard:


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
Removed the phase element restricting leaderboard posts.

# Issues this PR resolves
#437 

# A checklist for hand testing
- [ ] Open a competition with multiple phases on it. Submit to each one. Add each submission to leaderboard. See if the one posted on the leaderboard is the selected one. 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge

