### PR TITLE
API docs fixes (competition creation status)

### DIFF
--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -228,3 +228,8 @@ class CompetitionParticipantSerializer(serializers.ModelSerializer):
             'email',
             'status',
         )
+
+
+class FrontPageCompetitionsSerializer(serializers.Serializer):
+    popular_comps = CompetitionSerializerSimple(many=True)
+    featured_comps = CompetitionSerializerSimple(many=True)

--- a/src/apps/api/urls.py
+++ b/src/apps/api/urls.py
@@ -32,26 +32,22 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    # url('^query/', search.query),
     path('my_profile/', profiles.GetMyProfile.as_view()),
     path('datasets/completed/<uuid:key>/', datasets.upload_completed),
     path('upload_submission_scores/<int:submission_pk>/', submissions.upload_submission_scores),
+    path('can_make_submission/<phase_id>/', submissions.can_make_submission, name="can_make_submission"),
     path('add_submission_to_leaderboard/<int:submission_pk>/', leaderboards.add_submission_to_leaderboard, name='add_submission_to_leaderboard'),
-    path('datasets/create_dump/<int:competition_id>/', datasets.create_competition_dump),
     path('user_lookup/', profiles.user_lookup),
     path('analytics/', analytics.AnalyticsView.as_view(), name='analytics_api'),
 
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('api-token-auth/', obtain_auth_token),
 
-    # path('docs/', include_docs_urls(
-    #     title='Codalab Competitions V2',
-    #     permission_classes=(AllowAny,),
-    # )),
+    # API Docs
     re_path(r'docs(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     path('docs/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
-    path('can_make_submission/<phase_id>/', submissions.can_make_submission, name="can_make_submission"),
+
     # Include this at the end so our URLs above run first, like /datasets/completed/<pk>/ before /datasets/<pk>/
     path('', include(router.urls)),
 ]

--- a/src/apps/api/urls.py
+++ b/src/apps/api/urls.py
@@ -6,7 +6,6 @@ from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.routers import SimpleRouter
 from rest_framework.permissions import AllowAny
 
-from api.views.competitions import front_page_competitions
 from .views import analytics, competitions, datasets, profiles, leaderboards, submissions, tasks, queues
 
 
@@ -55,5 +54,4 @@ urlpatterns = [
     path('can_make_submission/<phase_id>/', submissions.can_make_submission, name="can_make_submission"),
     # Include this at the end so our URLs above run first, like /datasets/completed/<pk>/ before /datasets/<pk>/
     path('', include(router.urls)),
-    path('front_page_competitions/', front_page_competitions, name='front_page_competitions'),
 ]

--- a/src/apps/api/urls.py
+++ b/src/apps/api/urls.py
@@ -12,7 +12,6 @@ from .views import analytics, competitions, datasets, profiles, leaderboards, su
 
 router = SimpleRouter()
 router.register('competitions', competitions.CompetitionViewSet)
-router.register('competition_status', competitions.CompetitionCreationTaskStatusViewSet)
 router.register('phases', competitions.PhaseViewSet, 'phases')
 router.register('submissions', submissions.SubmissionViewSet)
 router.register('datasets', datasets.DataViewSet)

--- a/src/apps/api/urls.py
+++ b/src/apps/api/urls.py
@@ -23,7 +23,7 @@ router.register('queues', queues.QueueViewSet, 'queues')
 
 schema_view = get_schema_view(
     openapi.Info(
-        title="Codalab Competitions API",
+        title="Codabench API",
         default_version='v1',
     ),
     validators=['flex', 'ssv'],

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -6,17 +6,15 @@ from tempfile import SpooledTemporaryFile, NamedTemporaryFile
 from django.db import IntegrityError
 from django.db.models import Subquery, OuterRef, Count, Q, F, Case, When
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema, no_body
 from rest_framework import status
-from rest_framework.decorators import action, api_view, permission_classes
+from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.filters import SearchFilter
 from rest_framework.generics import get_object_or_404
-from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.viewsets import ModelViewSet, GenericViewSet
+from rest_framework.viewsets import ModelViewSet
 
 from api.serializers.competitions import CompetitionSerializer, CompetitionSerializerSimple, PhaseSerializer, \
     CompetitionCreationTaskStatusSerializer, CompetitionDetailSerializer, CompetitionParticipantSerializer, \

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -279,7 +279,7 @@ class CompetitionViewSet(ModelViewSet):
         return Response(serializer.data)
 
     @swagger_auto_schema(responses={200: FrontPageCompetitionsSerializer()})
-    @action(detail=False, methods=('GET',))
+    @action(detail=False, methods=('GET',), permission_classes=(AllowAny,))
     def front_page(self, request):
         popular_comps = get_popular_competitions()
         featured_comps = get_featured_competitions(excluded_competitions=popular_comps)

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -285,10 +285,10 @@ class CompetitionViewSet(ModelViewSet):
         featured_comps = get_featured_competitions(excluded_competitions=popular_comps)
         popular_comps_serializer = CompetitionSerializerSimple(popular_comps, many=True)
         featured_comps_serializer = CompetitionSerializerSimple(featured_comps, many=True)
-        return Response(data=FrontPageCompetitionsSerializer({
+        return Response(data={
             "popular_comps": popular_comps_serializer.data,
             "featured_comps": featured_comps_serializer.data
-        }).data)
+        })
 
     @swagger_auto_schema(request_body=no_body, responses={201: CompetitionCreationTaskStatusSerializer()})
     @action(detail=True, methods=('POST',), serializer_class=CompetitionCreationTaskStatusSerializer)

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -274,6 +274,17 @@ class CompetitionViewSet(ModelViewSet):
         serializer = CompetitionCreationTaskStatusSerializer(competition_creation_status)
         return Response(serializer.data)
 
+    @action(detail=False, methods=('GET',))
+    def front_page(self, request):
+        popular_comps = get_popular_competitions()
+        featured_comps = get_featured_competitions(excluded_competitions=popular_comps)
+        popular_comps_serializer = CompetitionSerializerSimple(popular_comps, many=True)
+        featured_comps_serializer = CompetitionSerializerSimple(featured_comps, many=True)
+        return Response(data={
+            "popular_comps": popular_comps_serializer.data,
+            "featured_comps": featured_comps_serializer.data
+        })
+
     def _ensure_organizer_participants_accepted(self, instance):
         CompetitionParticipant.objects.filter(
             user__in=instance.collaborators.all()
@@ -286,19 +297,6 @@ class CompetitionViewSet(ModelViewSet):
     def perform_update(self, serializer):
         instance = serializer.save()
         self._ensure_organizer_participants_accepted(instance)
-
-
-@api_view(['GET'])
-@permission_classes((AllowAny,))
-def front_page_competitions(request):
-    popular_comps = get_popular_competitions()
-    featured_comps = get_featured_competitions(excluded_competitions=popular_comps)
-    popular_comps_serializer = CompetitionSerializerSimple(popular_comps, many=True)
-    featured_comps_serializer = CompetitionSerializerSimple(featured_comps, many=True)
-    return Response(data={
-        "popular_comps": popular_comps_serializer.data,
-        "featured_comps": featured_comps_serializer.data
-    }, status=status.HTTP_200_OK)
 
 
 class PhaseViewSet(ModelViewSet):

--- a/src/apps/api/views/datasets.py
+++ b/src/apps/api/views/datasets.py
@@ -1,6 +1,5 @@
 import os
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
 from django.db.models import Q
 from django.http import Http404
@@ -13,7 +12,6 @@ from rest_framework.viewsets import ModelViewSet
 
 from api.pagination import BasicPagination
 from api.serializers import datasets as serializers
-from competitions.models import Competition
 from datasets.models import Data, DataGroup
 from utils.data import make_url_sassy
 

--- a/src/apps/api/views/datasets.py
+++ b/src/apps/api/views/datasets.py
@@ -130,20 +130,3 @@ def upload_completed(request, key):
         unpack_competition.apply_async((dataset.pk,))
 
     return Response({"key": dataset.key})
-
-
-@api_view(['POST'])
-def create_competition_dump(request, competition_id):
-    try:
-        comp = Competition.objects.get(pk=competition_id)
-        if not request.user == comp.created_by:
-            return Response({"error": "Denied. You do not have access"}, status=status.HTTP_403_FORBIDDEN)
-        from competitions.tasks import create_competition_dump
-        create_competition_dump.delay(competition_id)
-        return Response(
-            {
-                "status": "Success. Competition dump is being created."
-            },
-            status=status.HTTP_202_ACCEPTED)
-    except ObjectDoesNotExist:
-        return Response({"error": "Competition not found!"}, status=status.HTTP_403_FORBIDDEN)

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -419,8 +419,9 @@ def create_competition_dump(competition_pk, keys_instead_of_files=True):
                 )
 
         # -------- Competition Terms -------
-        yaml_data['terms'] = 'terms.md'
-        zip_file.writestr('terms.md', comp.terms)
+        if comp.terms:
+            yaml_data['terms'] = 'terms.md'
+            zip_file.writestr('terms.md', comp.terms)
 
         # -------- Competition Pages -------
         yaml_data['pages'] = []

--- a/src/static/js/ours/client.js
+++ b/src/static/js/ours/client.js
@@ -56,7 +56,7 @@ CODALAB.api = {
         return CODALAB.api.request('POST', `${URLS.API}competitions/${pk}/email_all_participants/`, {message: message})
     },
     get_front_page_competitions: function (data) {
-        return CODALAB.api.request('GET', URLS.API + "front_page_competitions/", data)
+        return CODALAB.api.request('GET', `${URLS.API}competitions/front_page/`, data)
     },
     get_competition_files: pk => {
         return CODALAB.api.request('GET', `${URLS.API}competitions/${pk}/get_files/`)

--- a/src/static/js/ours/client.js
+++ b/src/static/js/ours/client.js
@@ -32,7 +32,7 @@ CODALAB.api = {
         return CODALAB.api.request('POST', URLS.API + "competitions/", data)
     },
     get_competition_creation_status: function (key) {
-        return CODALAB.api.request('GET', `${URLS.API}competition_status/${key}/`)
+        return CODALAB.api.request('GET', `${URLS.API}competitions/creation_status/${key}/`)
     },
     update_competition: function (data, pk) {
         return CODALAB.api.request('PATCH', URLS.API + "competitions/" + pk + "/", data)

--- a/src/static/js/ours/client.js
+++ b/src/static/js/ours/client.js
@@ -61,6 +61,9 @@ CODALAB.api = {
     get_competition_files: pk => {
         return CODALAB.api.request('GET', `${URLS.API}competitions/${pk}/get_files/`)
     },
+    create_competition_dump: function (pk) {
+        return CODALAB.api.request('POST', `${URLS.API}competitions/${pk}/create_dump/`)
+    },
     /*---------------------------------------------------------------------
          Submissions
     ---------------------------------------------------------------------*/
@@ -125,9 +128,6 @@ CODALAB.api = {
     },
     delete_datasets: function(pk_list) {
         return CODALAB.api.request('POST', `${URLS.API}datasets/delete_many/`, pk_list)
-    },
-    create_dump: function (competition_id) {
-        return CODALAB.api.request('POST', URLS.API + "datasets/create_dump/" + competition_id + "/")
     },
     /**
      * Creates a dataset

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -176,7 +176,7 @@
         self.show_modal = selector => $(selector).modal('show')
 
         self.create_dump = () => {
-            CODALAB.api.create_dump(self.competition.id)
+            CODALAB.api.create_competition_dump(self.competition.id)
                 .done(data => {
                     self.tr_show = true
                     toastr.success("Success! Your competition dump is being created.")
@@ -193,11 +193,6 @@
                     self.files = data
                     self.tr_show = false
                     self.update()
-
-                    if (e) {
-                        // Only display toast if activated from button, not CODALAB.event
-                        toastr.success('Table Updated')
-                    }
                 })
                 .fail(response => {
                     toastr.error('Error Retrieving Competition Files')

--- a/src/urls.py
+++ b/src/urls.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.conf.urls import include
-from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import path
 
 urlpatterns = [
@@ -29,7 +29,7 @@ urlpatterns = [
 
 if settings.DEBUG:
     # Static files for local dev, so we don't have to collectstatic and such
-    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_URL)
+    urlpatterns += staticfiles_urlpatterns()
 
     # Django debug toolbar
     import debug_toolbar


### PR DESCRIPTION
# @ mention of reviewers
@dde6khkg @Logan-Ruf 


# A brief description of the purpose of the changes contained in this PR.

Previously the api docs had too many unorganized endpoints. I'd like to consolidate _at least_ a couple endpoints in this PR:

### Old
![image](https://user-images.githubusercontent.com/2185159/90168458-f6bea480-dd51-11ea-9fc0-82e2cac74b17.png)


### Newer 
![image](https://user-images.githubusercontent.com/2185159/90168433-edcdd300-dd51-11ea-87c7-87a1a6fe16f9.png)



# Issues this PR resolves
#482 

# A checklist for hand testing
- [x] api docs shows resources nicely


# TODO
- [x] Competition creation status -> competitions/creation_status/
- [x] Front page competitions -> competitions/front_page/
- [x] ~my profile -> users/me/ or something similar~ will tackle this later, maybe if we end up implementing djoser or something
- [x] ~upload_submission_scores ???~ may take a bit to refactor this, sticking with the other 3 for this small pr
- [x] datasets/create_dump -> competitions/create_dump
- [x] ~can_make_submission~ also moving to later refactor



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

