### PR TITLE
Fix date selection glitch on phase edit page

### DIFF
--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -257,6 +257,7 @@
                         self.form_updated()
                     }
                 }
+
                 var start_options = Object.assign({}, datetime_options, {endCalendar: self.refs.calendar_end})
                 var end_options = Object.assign({}, datetime_options, {startCalendar: self.refs.calendar_start})
 
@@ -265,6 +266,8 @@
 
                 self.has_initialized_calendars = true
             }
+            $(self.refs.calendar_start).calendar('set date', self.phases[self.selected_phase_index].start)
+            $(self.refs.calendar_end).calendar('set date', self.phases[self.selected_phase_index].end)
         }
 
         self.close_modal = function () {


### PR DESCRIPTION
# @ mention of reviewers
@gibsonbailey 


# A brief description of the purpose of the changes contained in this PR.
This PR fixes a bug on the phase edit menu where the start/end dates change to the previously selected phase's dates.


# Issues this PR resolves
#503 


# A checklist for hand testing
- [x] Edit the start/end dates on a phase
- [x] Close the edit menu, then edit the start/end dates on a different phase
- [x] Make sure the start/end dates are correct on the second phase


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

