### PR TITLE
Fix StrategyFactory not returning ManualMode

### DIFF
--- a/src/apps/leaderboards/strategies.py
+++ b/src/apps/leaderboards/strategies.py
@@ -107,14 +107,14 @@ class StrategyFactory:
 
     @staticmethod
     def create_by_submission_rule(submission_rule):
-        if submission_rule is None:
-            return ManualModeStrategy()
-        elif Leaderboard.FORCE_LAST == submission_rule:
+        if Leaderboard.FORCE_LAST == submission_rule:
             return LastestModeStrategy()
         elif Leaderboard.FORCE_LATEST_MULTIPLE == submission_rule:
             return AllModeStrategy()
         elif Leaderboard.FORCE_BEST == submission_rule:
             return BestModeStrategy()
+        else:
+            return ManualModeStrategy()
 
 
 def put_on_leaderboard_by_submission_rule(request, submission_pk, submission_rule):


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Fix StrategyFactory not returning ManualMode


# Issues this PR resolves
Errors thrown during /api/upload_submission_scores`

# A checklist for hand testing
- [x] `/api/upload_submission_scores` should no longer throw an exception for competitions with manual leader edits enables


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Ready to merge

